### PR TITLE
docs(db name): 更新文件和注释的默认数据库名，与配置文件保持一致

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ nacosSync
 
 The default is Mysql database, which can support other relational databases
 
-- Build db schema, the default schema name nacos_Sync.
+- Build db schema, the default schema name nacos_sync.
 - Tables do not need to be created separately, which is conducive to hibernate's automatic table creation function.
 - If the automatic table creation fails, you can build the table nacosSync.sql, the table statement is in the bin folder.
 

--- a/nacossync-distribution/bin/nacosSync.sql
+++ b/nacossync-distribution/bin/nacosSync.sql
@@ -1,5 +1,5 @@
 /******************************************/
-/*   DB name = nacos_Sync   */
+/*   DB name = nacos_sync   */
 /*   Table name = cluster   */
 /******************************************/
 CREATE TABLE `cluster` (
@@ -11,7 +11,7 @@ CREATE TABLE `cluster` (
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /******************************************/
-/*   DB name = nacos_Sync   */
+/*   DB name = nacos_sync   */
 /*   Table name = system_config   */
 /******************************************/
 CREATE TABLE `system_config` (
@@ -22,7 +22,7 @@ CREATE TABLE `system_config` (
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /******************************************/
-/*   DB name = nacos_Sync   */
+/*   DB name = nacos_sync   */
 /*   Table name = task   */
 /******************************************/
 CREATE TABLE `task` (


### PR DESCRIPTION
**缘由：**
最近在使用 Nacos Sync 进行迁移的时候发现文档里面的数据库名和实际配置文件使用的不一致，造成了一些不必要的麻烦。建议统一

**改动：**
将 `README` 和 `nacosSync.sql` 文件里的数据库名统一改为了 `nacos_sync`。

**成果：**
现在数据库名在文档和实际使用时保持一致

**其他：**
关于统一为 `nacos_sync` 还是 `nacos_Sync` 的思考：
- 个人认为不要混用驼峰和下划线方式命名为好
- 参照了阿里的 Java 开发手册里面关于表名的规约，使用下划线和小写字母的形式

