### PR TITLE
fixbug:监听zk变化后获取到event的data的path路径包含服务详细信息，正则表达式缺少后缀模糊匹配

### DIFF
--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/util/StringUtils.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/util/StringUtils.java
@@ -39,7 +39,7 @@ public final class StringUtils {
     private static final Pattern IP_PORT_PATTERN = Pattern
             .compile(".*/(.*)://(\\d+\\.\\d+\\.\\d+\\.\\d+):(\\d+)");
 	private static final Pattern DUBBO_PROVIDER_PATTERN = Pattern
-            .compile("/dubbo/(.*)/providers/");
+            .compile("/dubbo/(.*)/providers/(.*)");
 
     /**
      * parse key-value pair.


### PR DESCRIPTION
现象：
    在创建zk到nacos的同步任务后，第一次会把该服务的所有提供者更新，但是后面此服务的变动不会再更新

原因：
   发现在7月份增加了是否是dubbo提供者的判断（!com.alibaba.nacossync.util.StringUtils.isDubboProviderPath(path)），但这个判断里面的正则针对监听到的event时间中的path来说是有问题的。event中获取到的path是这样的（/dubbo/com.alibaba.dubbo.demo.DemoService/providers/dubbo://10.108.2.128:20660/com.alibaba.dubbo.demo.DemoService?anyhost=true&application=demo-provider&bean.name=com.alibaba.dubbo.demo.DemoService&dubbo=2.0.2&generic=false&interface=com.alibaba.dubbo.demo.DemoService&methods=sayHello&pid=16612&side=provider&timestamp=1602755572949），而正则表达式（/dubbo/(.*)/providers/）匹配这个返回false。

更改：
   修改正则表达式/dubbo/(.*)/providers/为/dubbo/(.*)/providers/(.*)