### PR TITLE
优化serviceName sharding处理

### DIFF
--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
@@ -367,6 +367,8 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
      */
     private boolean isProcess(TaskDO taskDO, NamingService destNamingService, String serviceName) {
         try {
+            if (IGNORED_DUBBO_PATH.contains(serviceName))
+                return false;
             sharding.doSharding(null, new ArrayList<>(Arrays.asList(serviceName)));
             deregisterService(destNamingService, sharding.getChangeService(), taskDO);
             if (sharding.getLocalServices(null).contains(serviceName)) {

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
@@ -160,13 +160,18 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
 
     private void registerAllInstances(TaskDO taskDO, NamingService destNamingService) throws Exception {
         CuratorFramework zk = zookeeperServerHolder.get(taskDO.getSourceClusterId(), "");
+        sharding.start(taskDO);//幂等 可重复添加
         if (!ALL_SERVICE_NAME_PATTERN.equals(taskDO.getServiceName())) {
-            registerALLInstances0(taskDO, destNamingService, zk, taskDO.getServiceName());
+            List<String> serviceList = new ArrayList<>();
+            serviceList.add(taskDO.getServiceName());
+            sharding.doSharding(null, serviceList);
+            TreeSet<String> shardingServices = sharding.getLocalServices(null);
+            if (shardingServices.contains(taskDO.getServiceName())) {
+                registerALLInstances0(taskDO, destNamingService, zk, taskDO.getServiceName());
+            }
         } else {
             // 同步全部
             List<String> serviceList = zk.getChildren().forPath(DUBBO_ROOT_PATH);
-            //add
-            sharding.start(taskDO);//幂等 可重复添加
             sharding.doSharding(null, filterNoProviderPath(serviceList));
             TreeSet<String> shardingServices = sharding.getLocalServices(null);
             for (String serviceName : serviceList) {
@@ -364,8 +369,9 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
      */
     private boolean isProcess(TaskDO taskDO, NamingService destNamingService, String serviceName) {
         try {
-            CuratorFramework zk = zookeeperServerHolder.get(taskDO.getSourceClusterId(), "");
-            sharding.doSharding(null, filterNoProviderPath(zk.getChildren().forPath(DUBBO_ROOT_PATH)));
+            List<String> serviceList = new ArrayList<String>();
+            serviceList.add(serviceName);
+            sharding.doSharding(null, serviceList);
             deregisterService(destNamingService, sharding.getChangeService(), taskDO);
             if (sharding.getLocalServices(null).contains(serviceName)) {
                 return true;

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
@@ -367,7 +367,7 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
      */
     private boolean isProcess(TaskDO taskDO, NamingService destNamingService, String serviceName) {
         try {
-            sharding.doSharding(null, Arrays.asList(serviceName));
+            sharding.doSharding(null, new ArrayList<>(Arrays.asList(serviceName)));
             deregisterService(destNamingService, sharding.getChangeService(), taskDO);
             if (sharding.getLocalServices(null).contains(serviceName)) {
                 return true;

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
@@ -162,9 +162,7 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
         CuratorFramework zk = zookeeperServerHolder.get(taskDO.getSourceClusterId(), "");
         sharding.start(taskDO);//幂等 可重复添加
         if (!ALL_SERVICE_NAME_PATTERN.equals(taskDO.getServiceName())) {
-            List<String> serviceList = new ArrayList<>();
-            serviceList.add(taskDO.getServiceName());
-            sharding.doSharding(null, serviceList);
+            sharding.doSharding(null, new ArrayList<>(Arrays.asList(taskDO.getServiceName())));
             TreeSet<String> shardingServices = sharding.getLocalServices(null);
             if (shardingServices.contains(taskDO.getServiceName())) {
                 registerALLInstances0(taskDO, destNamingService, zk, taskDO.getServiceName());
@@ -369,9 +367,7 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
      */
     private boolean isProcess(TaskDO taskDO, NamingService destNamingService, String serviceName) {
         try {
-            List<String> serviceList = new ArrayList<String>();
-            serviceList.add(serviceName);
-            sharding.doSharding(null, serviceList);
+            sharding.doSharding(null, Arrays.asList(serviceName));
             deregisterService(destNamingService, sharding.getChangeService(), taskDO);
             if (sharding.getLocalServices(null).contains(serviceName)) {
                 return true;

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/sharding/ConsistentHashServiceSharding.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/sharding/ConsistentHashServiceSharding.java
@@ -5,10 +5,7 @@ import com.alibaba.nacossync.util.SkyWalkerUtil;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * Created by maj on 2020/10/27.
@@ -23,7 +20,7 @@ public class ConsistentHashServiceSharding extends AbstractServiceSharding {
 
     private SortedMap<Integer, String> virtualNodes = new TreeMap<Integer, String>();
 
-    private static final int VIRTUAL_COUNT = 5;
+    private static final int VIRTUAL_COUNT = 100;
 
     public ConsistentHashServiceSharding() {
         super();


### PR DESCRIPTION
zk->nacos，收到节点变更时间时，取消之前获取全量serviceName做重做sharding的方式，改为变化serviceName重做sharding，在serviceName量级较大时，提高sync出现性能。