### PR TITLE
do not add FinishedTask if syncManagerService return false， add group parameter for getAllInstances at sync

### DIFF
--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/event/listener/EventListener.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/event/listener/EventListener.java
@@ -62,9 +62,12 @@ public class EventListener {
 
         try {
             long start = System.currentTimeMillis();
-            syncManagerService.sync(syncTaskEvent.getTaskDO());
-            skyWalkerCacheServices.addFinishedTask(syncTaskEvent.getTaskDO());
-            metricsManager.record(MetricsStatisticsType.SYNC_TASK_RT, System.currentTimeMillis() - start);
+            if (syncManagerService.sync(syncTaskEvent.getTaskDO())) {                
+                skyWalkerCacheServices.addFinishedTask(syncTaskEvent.getTaskDO());
+                metricsManager.record(MetricsStatisticsType.SYNC_TASK_RT, System.currentTimeMillis() - start);
+            } else {
+                log.warn("listenerSyncTaskEvent sync failure");
+            }                
         } catch (Exception e) {
             log.warn("listenerSyncTaskEvent process error", e);
         }
@@ -76,9 +79,12 @@ public class EventListener {
 
         try {
             long start = System.currentTimeMillis();
-            syncManagerService.delete(deleteTaskEvent.getTaskDO());
-            skyWalkerCacheServices.addFinishedTask(deleteTaskEvent.getTaskDO());
-            metricsManager.record(MetricsStatisticsType.DELETE_TASK_RT, System.currentTimeMillis() - start);
+            if (syncManagerService.delete(deleteTaskEvent.getTaskDO())) {
+                skyWalkerCacheServices.addFinishedTask(deleteTaskEvent.getTaskDO());
+                metricsManager.record(MetricsStatisticsType.DELETE_TASK_RT, System.currentTimeMillis() - start);
+            } else {
+                log.warn("listenerDeleteTaskEvent delete failure");
+            }                
         } catch (Exception e) {
             log.warn("listenerDeleteTaskEvent process error", e);
         }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImpl.java
@@ -109,7 +109,7 @@ public class NacosSyncToNacosServiceImpl implements SyncService {
                     try {
 
                         List<Instance> sourceInstances = sourceNamingService.getAllInstances(taskDO.getServiceName(),
-                            new ArrayList<>(), false);
+                            getGroupNameOrDefault(taskDO.getGroupName()), new ArrayList<>(), false);
                         // 先删除不存在的
                         this.removeInvalidInstance(taskDO, destNamingService, sourceInstances);
                         // 如果同步实例已经为空代表该服务所有实例已经下线,清除本地持有快照


### PR DESCRIPTION
1. 网络连接失败等原因导致syncManagerService.sync或delete方法返回false时，不将task加入finishedTaskMap，以便QuerySyncTaskTimer定时任务能够进行重试。
2. NacosSyncToNacosServiceImpl的sync方法获取实例时传入同步任务分组名称，以支持非DEFAULT_GROUP分组同步任务。
这个缺陷修复可能和问题 #243 有关。