### PR TITLE
对版本号统一管理;修复日志无限增大问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 node_modules
 test/derby.log
 /console-fe
+.flattened-pom.xml

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The path to the target file:
 
 ``` xml
 
-nacos-sync/nacossync-distribution/target/nacos-sync-0.4.7.zip
+nacos-sync/nacossync-distribution/target/nacos-sync-0.4.8.tar.gz
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Function
 
  - Console: provide API and console for management
- - Worker: provider the service registration synchronization. 
+ - Worker: provide the service registration synchronization. 
 
 ## Architecture
 
@@ -44,16 +44,9 @@ Info |      +------------+                   ^
      - NacosCluster target will dedup the synchronization information from Nacos.
      
 
-
-
-
-
-
-
 ## Quick Start:
  - Swagger API: http://127.0.0.1:8083/swagger-ui.html#/
  - Web Console: http://127.0.0.1:8083/
- - Others: TBD
 
 # NacosSync Migration User Guide
 
@@ -84,7 +77,7 @@ Before you begin, install the following:
 
 - 64bit OS: Linux/Unix/Mac/Windows supported, Linux/Unix/Mac recommended.
 - 64bit JDK 1.8+: downloads, JAVA_HOME settings.
-- Maven 3.2.x+: downloads, settings.
+- Maven 3.5.2+: [downloads](https://maven.apache.org/download.cgi), [settings](https://maven.apache.org/settings.html).
 - MySql 5.6.+
 
 ## Download & Build From Release
@@ -96,7 +89,7 @@ There are two ways to get NacosSync.
 
 ``` xml
 
-cd nacosSync/
+cd nacos-sync/
 mvn clean package -U
 
 ```
@@ -105,7 +98,7 @@ The path to the target file:
 
 ``` xml
 
-nacos-sync/nacossync-distribution/target/nacosSync.0.3.8.zip
+nacos-sync/nacossync-distribution/target/nacos-sync-0.4.7.zip
 
 ```
 
@@ -113,7 +106,7 @@ After extracting the installation package, the directory structure:
 
 ``` xml
 
-nacosSync
+nacos-sync
 ├── LICENSE
 ├── NOTICE
 ├── bin
@@ -124,7 +117,7 @@ nacosSync
 │   ├── application.properties
 │   └── logback-spring.xml
 ├── logs
-└── nacosSync-server.jar
+└── nacos-sync-server.jar
 
 ```
 
@@ -132,7 +125,7 @@ nacosSync
 
 The default is Mysql database, which can support other relational databases
 
-- Build db schema, the default schema name nacos_Sync.
+- Build db schema, the default schema name nacos_sync.
 - Tables do not need to be created separately, which is conducive to hibernate's automatic table creation function.
 - If the automatic table creation fails, you can build the table nacosSync.sql, the table statement is in the bin folder.
 
@@ -161,15 +154,6 @@ sh startup.sh  start
 
 ``` xml
 
-http://127.0.0.1:8083/#/serviceSync
+http://127.0.0.1:8083
 
 ```
-
-
-
-
-
-
-
-
-

--- a/nacossync-console/pom.xml
+++ b/nacossync-console/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>nacossync-parent</artifactId>
         <groupId>com.alibaba.nacossync</groupId>
-        <version>0.4.7</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -27,5 +27,4 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/nacossync-distribution/bin/shutdown.sh
+++ b/nacossync-distribution/bin/shutdown.sh
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pid=`ps ax | grep -i 'nacosSync' |grep java | grep -v grep | awk '{print $1}'`
+pid=`ps ax | grep -i 'nacos-sync' |grep java | grep -v grep | awk '{print $1}'`
 if [ -z "$pid" ] ; then
-        echo "No nacosSync running."
+        echo "no nacos-sync running."
         exit -1;
 fi
 
-echo "The nacosSync(${pid}) is running..."
+echo "the nacos-sync(${pid}) is running..."
 
 kill ${pid}
 
-echo "Send shutdown request to nacosSync(${pid}) OK"
+echo "Send shutdown request to nacos-sync(${pid}) OK"

--- a/nacossync-distribution/bin/startup.bat
+++ b/nacossync-distribution/bin/startup.bat
@@ -1,1 +1,1 @@
-java -jar ../nacosSync-server.jar -server -Xms2g -Xmx2g -Xmn1g -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=512m --spring.config.location=../conf/application.properties
+java -jar ../nacos-sync-server.jar -server -Xms2g -Xmx2g -Xmn1g -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=512m --spring.config.location=../conf/application.properties

--- a/nacossync-distribution/bin/startup.sh
+++ b/nacossync-distribution/bin/startup.sh
@@ -47,24 +47,24 @@ export BASE_DIR=`cd $(dirname $0)/..; pwd`
 
 
 JAVA_OPT="${JAVA_OPT} -server -Xms2g -Xmx2g -Xmn1g -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=512m"
-JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${BASE_DIR}/nacossync_java_heapdump.hprof"
+JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${BASE_DIR}/nacos-sync-java-heapdump.hprof"
 JAVA_OPT="${JAVA_OPT} -XX:-UseLargePages"
 JAVA_OPT="${JAVA_OPT} -Dspring.config.location=${BASE_DIR}/conf/application.properties"
 JAVA_OPT="${JAVA_OPT} -DnacosSync.home=${BASE_DIR}"
 
 JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
 if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]] ; then
-  JAVA_OPT="${JAVA_OPT} -Xlog:gc*:file=${BASE_DIR}/logs/nacossync_gc.log:time,tags:filecount=10,filesize=102400"
+  JAVA_OPT="${JAVA_OPT} -Xlog:gc*:file=${BASE_DIR}/logs/nacos-sync-gc.log:time,tags:filecount=10,filesize=102400"
 else
-  JAVA_OPT="${JAVA_OPT} -Xloggc:${BASE_DIR}/logs/nacossync_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
+  JAVA_OPT="${JAVA_OPT} -Xloggc:${BASE_DIR}/logs/nacos-sync-gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
 fi
 
-JAVA_OPT="${JAVA_OPT} -jar ${BASE_DIR}/nacosSync-server.jar"
+JAVA_OPT="${JAVA_OPT} -jar ${BASE_DIR}/nacos-sync-server.jar"
 JAVA_OPT="${JAVA_OPT} --logging.config=${BASE_DIR}/conf/logback-spring.xml"
 
-echo "=============JAVA_HOME:"$JAVA_HOME
-echo "=============BASE_DIR:"$BASE_DIR
-echo "=============JAVA:"$JAVA
+echo "JAVA_HOME:"$JAVA_HOME
+echo "BASE_DIR:"$BASE_DIR
+echo "JAVA:"$JAVA
 
 
 if [  ! -d "${BASE_DIR}/logs" ]; then
@@ -78,9 +78,9 @@ usage(){
 
 start(){
 
-echo "$JAVA ${JAVA_OPT}" > ${BASE_DIR}/logs/nacossync_start.out 2>&1 &
-nohup $JAVA ${JAVA_OPT} >> ${BASE_DIR}/logs/nacossync_start.out 2>&1 &
-echo "nacossync is starting，you can check the ${BASE_DIR}/logs/nacossync_start.out"
+echo "$JAVA ${JAVA_OPT}" > ${BASE_DIR}/logs/nacos-sync-start.out 2>&1 &
+nohup $JAVA ${JAVA_OPT} >> ${BASE_DIR}/logs/nacos-sync-start.out 2>&1 &
+echo "nacos-sync is starting，you can check the ${BASE_DIR}/logs/nacos-sync-start.out"
 
 }
 

--- a/nacossync-distribution/pom.xml
+++ b/nacossync-distribution/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>nacossync-parent</artifactId>
         <groupId>com.alibaba.nacossync</groupId>
-        <version>0.4.7</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>nacossync-distribution</artifactId>
 
     <build>
-        <finalName>nacosSync.${parent.version}</finalName>
+        <finalName>nacos-sync-${project.version}</finalName>
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/nacossync-distribution/release-nacossync.xml
+++ b/nacossync-distribution/release-nacossync.xml
@@ -17,7 +17,7 @@
     <id>bin</id>
     <includeBaseDirectory>true</includeBaseDirectory>
     <!-- file name after unzip -->
-    <baseDirectory>nacosSync</baseDirectory>
+    <baseDirectory>nacos-sync</baseDirectory>
     <formats>
         <format>dir</format>
         <format>tar.gz</format>
@@ -60,9 +60,9 @@
             <destName>NOTICE</destName>
         </file>
         <file>
-            <source>../nacossync-worker/target/nacosSync-server.${parent.version}.jar</source>
+            <source>../nacossync-worker/target/nacos-sync-server-${project.version}.jar</source>
             <outputDirectory></outputDirectory>
-            <destName>nacosSync-server.jar</destName>
+            <destName>nacos-sync-server.jar</destName>
         </file>
     </files>
 </assembly>

--- a/nacossync-test/pom.xml
+++ b/nacossync-test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>nacossync-parent</artifactId>
         <groupId>com.alibaba.nacossync</groupId>
-        <version>0.4.7</version>
+        <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -25,27 +25,20 @@
 
     <artifactId>nacossync-test</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
     <dependencies>
-
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-
         </dependency>
-
         <dependency>
             <groupId>com.alibaba.nacossync</groupId>
             <artifactId>nacossync-worker</artifactId>
-            <version>0.4.7</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
@@ -57,10 +50,8 @@
         <dependency>
             <groupId>com.ning</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>1.7.17</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -68,7 +59,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.9</version>
                 <configuration>
                     <parallel>methods</parallel>
                     <useUnlimitedThreads>true</useUnlimitedThreads>
@@ -76,6 +66,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/nacossync-test/pom.xml
+++ b/nacossync-test/pom.xml
@@ -31,9 +31,8 @@
             <artifactId>reactor-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.alibaba.nacossync</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>nacossync-worker</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/nacossync-worker/pom.xml
+++ b/nacossync-worker/pom.xml
@@ -16,29 +16,11 @@
     <parent>
         <artifactId>nacossync-parent</artifactId>
         <groupId>com.alibaba.nacossync</groupId>
-        <version>0.4.7</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>nacossync-worker</artifactId>
-    <version>0.4.7</version>
-    <properties>
-        <zookeeper.version>3.4.9</zookeeper.version>
-        <curator.version>4.1.0</curator.version>
-        <cloud.version>2020.0.2</cloud.version>
-        <mockito.version>1.10.19</mockito.version>
-        <nacos.client.verison>1.4.2</nacos.client.verison>
-    </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -60,7 +42,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,30 +62,24 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
-
         <!-- swagger2 -->
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>3.0.0</version>
         </dependency>
         <!--nacos-->
         <dependency>
             <groupId>com.alibaba.nacos</groupId>
             <artifactId>nacos-client</artifactId>
-            <version>${nacos.client.verison}</version>
         </dependency>
-
         <!--zookeeper-->
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>${zookeeper.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -112,11 +87,9 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
-            <version>${curator.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>
@@ -124,17 +97,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
-            <version>${curator.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-client</artifactId>
-            <version>${curator.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -142,14 +111,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <!-- eureka -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
-
-
         <!-- consul -->
         <dependency>
             <groupId>com.ecwid.consul</groupId>
@@ -158,16 +124,15 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
         </dependency>
     </dependencies>
+
     <build>
-        <finalName>nacosSync-server.${parent.version}</finalName>
+        <finalName>nacos-sync-server-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
@@ -183,7 +148,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
                 <configuration>
                     <excludes>
                         <exclude>application.properties</exclude>

--- a/nacossync-worker/src/main/resources/logback-spring.xml
+++ b/nacossync-worker/src/main/resources/logback-spring.xml
@@ -4,12 +4,13 @@
         <springProperty name="logPath"  scope="context" source="nacosSync.logs.path" defaultValue="${nacosSync.home}/logs"/>
         <property name="LOG_HOME" value="${logPath}" />
     <appender name="FILEINFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_HOME}/nacosSync.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/log-nacosSync-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>200MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
+        <file>${LOG_HOME}/nacos-sync.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_HOME}/log-nacos-sync-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>200MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
         <append>true</append>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -25,7 +26,6 @@
     </appender>
 
     <logger name="com.alibaba.nacossync" level="INFO"/>
-
     <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="INFO"/>
     <logger name="org.hibernate.type.descriptor.sql.BasicExtractor" level="INFO"/>
     <logger name="org.hibernate.SQL" level="INFO"/>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>com.alibaba.nacossync</groupId>
     <artifactId>nacossync-parent</artifactId>
-    <version>0.4.7</version>
+    <version>${revision}</version>
     <modules>
         <module>nacossync-console</module>
         <module>nacossync-worker</module>
@@ -25,17 +25,45 @@
     </modules>
     <packaging>pom</packaging>
     <properties>
+        <revision>0.4.7</revision>
+        <spring-boot.version>2.4.5</spring-boot.version>
+        <spring-cloud.version>2020.0.2</spring-cloud.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <zookeeper.version>3.4.9</zookeeper.version>
+        <curator.version>4.1.0</curator.version>
+        <mockito.version>1.10.19</mockito.version>
+        <nacos-client.verison>1.4.2</nacos-client.verison>
+        <lombok.verison>1.18.2</lombok.verison>
+        <swagger.verison>3.0.0</swagger.verison>
+        <consul-api.verison>1.3.1</consul-api.verison>
+        <commoms-lang3.verison>3.12.0</commoms-lang3.verison>
+        <guava.verison>30.1-jre</guava.verison>
+        <versions-maven-plugin.version>2.2</versions-maven-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spring.boot.version>2.4.5</spring.boot.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
+        <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
+        <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
+        <clirr-maven-plugin.version>2.7</clirr-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.7.8</jacoco-maven-plugin.version>
+        <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
+        <sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
+        <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
+        <flatten-maven-plugin.version>1.1.0</flatten-maven-plugin.version>
+        <dependency-mediator-maven-plugin.version>1.0.2</dependency-mediator-maven-plugin.version>
+        <extra-enforcer-rules.version>1.0-beta-4</extra-enforcer-rules.version>
+        <async-http-client.version>1.7.17</async-http-client.version>
     </properties>
 
     <scm>
         <url>git@github.com:nacos-group/nacos-sync.git</url>
         <connection>scm:git@github.com:nacos-group/nacos-sync.git</connection>
         <developerConnection>scm:git@github.com:nacos-group/nacos-sync.git</developerConnection>
-        <tag>nacossync-0.4.6</tag>
+        <tag>nacos-sync-${project.version}</tag>
     </scm>
     <developers>
         <developer>
@@ -58,7 +86,14 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -66,7 +101,82 @@
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <scope>provided</scope>
-                <version>1.18.2</version>
+                <version>${lombok.verison}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger2</artifactId>
+                <version>${swagger.verison}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger-ui</artifactId>
+                <version>${swagger.verison}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.alibaba.nacos</groupId>
+                <artifactId>nacos-client</artifactId>
+                <version>${nacos-client.verison}</version>
+            </dependency>
+            <!--zookeeper-->
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>slf4j-log4j12</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-recipes</artifactId>
+                <version>${curator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+                <version>${curator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-client</artifactId>
+                <version>${curator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>slf4j-api</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commoms-lang3.verison}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.verison}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.ning</groupId>
+                <artifactId>async-http-client</artifactId>
+                <version>${async-http-client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -76,22 +186,22 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.2</version>
+                <version>${versions-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>com.github.vongosling</groupId>
                 <artifactId>dependency-mediator-maven-plugin</artifactId>
-                <version>1.0.2</version>
+                <version>${dependency-mediator-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>clirr-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>${clirr-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-ban-circular-dependencies</id>
@@ -110,14 +220,14 @@
                     <dependency>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>extra-enforcer-rules</artifactId>
-                        <version>1.0-beta-4</version>
+                        <version>${extra-enforcer-rules.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -126,11 +236,10 @@
                     <showWarnings>true</showWarnings>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -143,7 +252,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>${maven-resources-plugin.version}</version>
                 <configuration>
                     <!-- We are not suppose to setup the customer resources here -->
                     <encoding>${project.build.sourceEncoding}</encoding>
@@ -152,12 +261,12 @@
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.3.0</version>
+                <version>${coveralls-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.8</version>
+                <version>${jacoco-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>
@@ -196,7 +305,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
@@ -206,12 +314,40 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
+                <version>${findbugs-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>${sonar-maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <pomElements>
+                        <dependencies>expand</dependencies>
+                    </pomElements>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -219,12 +355,22 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>${maven-assembly-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${spring.boot.version}</version>
+                    <version>${spring-boot.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -234,7 +380,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
+                <version>${findbugs-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </modules>
     <packaging>pom</packaging>
     <properties>
-        <revision>0.4.7</revision>
+        <revision>0.4.8</revision>
         <spring-boot.version>2.4.5</spring-boot.version>
         <spring-cloud.version>2020.0.2</spring-cloud.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -177,6 +177,11 @@
                 <groupId>com.ning</groupId>
                 <artifactId>async-http-client</artifactId>
                 <version>${async-http-client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>nacossync-worker</artifactId>
+                <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
fixed #285
1. dependency的版本号全部挪到父pom的dependencyManagement;
2. plugin的版本号全部挪到父pom的pluginManagement;
3. nacosSync名称修改为nacos-sync;
4. 父pom和子pom的version统一由revision管理，只需一处修改;
5. 修复一些readme.md中的明显错误;
6. 修复日志文件永不删除的问题，0.4.7日志一直不删除，生产上已经有100G的日志。

本次修改已验证无问题，图片如下：
1. 打包没问题
<img width="299" alt="image" src="https://user-images.githubusercontent.com/99602200/171197779-ade6e88f-35f6-4d86-8ee3-f3c350f722d7.png">

2. 启动正常
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/99602200/171197917-1f934f74-5923-4abc-97b5-f438f2599458.png">

3. 页面访问正常
<img width="914" alt="image" src="https://user-images.githubusercontent.com/99602200/171198024-c68a5653-ef2f-4cb1-97f3-b3459a0b034d.png">
