### PR TITLE
Feature/支持Nacos2.x 实例批量同步以及多线程同步实例

### DIFF
--- a/nacossync-distribution/bin/nacosSync.sql
+++ b/nacossync-distribution/bin/nacosSync.sql
@@ -10,6 +10,8 @@ CREATE TABLE `cluster` (
   `connect_key_list` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
   `user_name` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
   `password` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
+  `namespace` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
+  `cluster_level` int default 0,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /******************************************/
@@ -39,5 +41,6 @@ CREATE TABLE `task` (
   `task_status` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
   `version` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
   `worker_ip` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
+  `status` int default null ,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

--- a/nacossync-worker/pom.xml
+++ b/nacossync-worker/pom.xml
@@ -26,7 +26,7 @@
         <curator.version>4.1.0</curator.version>
         <cloud.version>2020.0.2</cloud.version>
         <mockito.version>1.10.19</mockito.version>
-        <nacos.client.verison>1.4.2</nacos.client.verison>
+        <nacos.client.verison>2.1.0</nacos.client.verison>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/cache/SkyWalkerCacheServices.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/cache/SkyWalkerCacheServices.java
@@ -96,10 +96,25 @@ public class SkyWalkerCacheServices {
 
         return finishedTaskMap.get(operationId);
     }
+    
+    public FinishedTask getFinishedTask(String operationId) {
+        if (StringUtils.isEmpty(operationId)) {
+            return null;
+        }
+        return finishedTaskMap.get(operationId);
+    }
+    
+    public FinishedTask removeFinishedTask(String operationId) {
+        if (StringUtils.isEmpty(operationId)) {
+            return null;
+        }
+        return finishedTaskMap.remove(operationId);
+    }
 
     public Map<String, FinishedTask> getFinishedTaskMap() {
 
         return finishedTaskMap;
     }
+    
 
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/SkyWalkerConstants.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/SkyWalkerConstants.java
@@ -30,5 +30,6 @@ public class SkyWalkerConstants {
     public static final String SOURCE_CLUSTERID_KEY = "sourceClusterId";
     public static final String MANAGEMENT_PORT_KEY="management.port";
     public static final String MANAGEMENT_CONTEXT_PATH_KEY="management.context-path";
+    public static final String SYNC_INSTANCE_TAG="sync.instance.tag";
 
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/SkyWalkerConstants.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/SkyWalkerConstants.java
@@ -31,5 +31,6 @@ public class SkyWalkerConstants {
     public static final String MANAGEMENT_PORT_KEY="management.port";
     public static final String MANAGEMENT_CONTEXT_PATH_KEY="management.context-path";
     public static final String SYNC_INSTANCE_TAG="sync.instance.tag";
+    public static final Integer MAX_THREAD_NUM = 200;
 
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/ClusterAccessService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/ClusterAccessService.java
@@ -103,4 +103,12 @@ public class ClusterAccessService implements PageQueryService<ClusterDO> {
         predicates.add(criteriaBuilder.like(root.get("clusterName"), "%" + queryCondition.getServiceName() + "%"));
         return predicates;
     }
+    
+    public int findClusterLevel(String sourceClusterId){
+        ClusterDO clusterDO = clusterRepository.findByClusterId(sourceClusterId);
+        if (clusterDO != null) {
+            return clusterDO.getClusterLevel();
+        }
+        return -1;
+    }
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/TaskAccessService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/TaskAccessService.java
@@ -114,5 +114,9 @@ public class TaskAccessService implements PageQueryService<TaskDO> {
 
                 }, pageable);
     }
+    
+    public List<TaskDO> findServiceNameIsNull() {
+        return taskRepository.findAllByServiceNameEquals("ALL");
+    }
 
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/repository/TaskRepository.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/repository/TaskRepository.java
@@ -41,5 +41,12 @@ public interface TaskRepository extends CrudRepository<TaskDO, Integer>, JpaRepo
     List<TaskDO> findAllByTaskIdIn(List<String> taskIds);
     
     List<TaskDO> getAllByWorkerIp(String workerIp);
+    
+    /**
+     * query service is all，use ns leven sync data
+     * @param serviceName
+     * @return
+     */
+    List<TaskDO> findAllByServiceNameEquals(String serviceName);
 
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/event/listener/EventListener.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/event/listener/EventListener.java
@@ -88,7 +88,5 @@ public class EventListener {
         } catch (Exception e) {
             log.warn("listenerDeleteTaskEvent process error", e);
         }
-
     }
-
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/event/listener/EventListener.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/event/listener/EventListener.java
@@ -62,7 +62,7 @@ public class EventListener {
 
         try {
             long start = System.currentTimeMillis();
-            if (syncManagerService.sync(syncTaskEvent.getTaskDO())) {                
+            if (syncManagerService.sync(syncTaskEvent.getTaskDO(), null)) {
                 skyWalkerCacheServices.addFinishedTask(syncTaskEvent.getTaskDO());
                 metricsManager.record(MetricsStatisticsType.SYNC_TASK_RT, System.currentTimeMillis() - start);
             } else {

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncManagerService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncManagerService.java
@@ -52,9 +52,9 @@ public class SyncManagerService implements InitializingBean, ApplicationContextA
 
     }
 
-    public boolean sync(TaskDO taskDO) {
+    public boolean sync(TaskDO taskDO, Integer index) {
 
-        return getSyncService(taskDO.getSourceClusterId(), taskDO.getDestClusterId()).sync(taskDO);
+        return getSyncService(taskDO.getSourceClusterId(), taskDO.getDestClusterId()).sync(taskDO, index);
 
     }
 

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncService.java
@@ -35,15 +35,18 @@ public interface SyncService {
      * execute sync
      *
      * @param taskDO
+     * @param index
      * @return
      */
-    boolean sync(TaskDO taskDO);
+    boolean sync(TaskDO taskDO, Integer index);
 
     /**
      * Determines that the current instance data is from another source cluster
      */
     default boolean needSync(Map<String, String> sourceMetaData) {
-        return StringUtils.isBlank(sourceMetaData.get(SkyWalkerConstants.SOURCE_CLUSTERID_KEY));
+        boolean syncTag = StringUtils.isBlank(sourceMetaData.get(SkyWalkerConstants.SYNC_INSTANCE_TAG));
+        boolean blank = StringUtils.isBlank(sourceMetaData.get(SkyWalkerConstants.SOURCE_CLUSTERID_KEY));
+        return syncTag && blank;
     }
 
     /**

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/holder/AbstractServerHolderImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/holder/AbstractServerHolderImpl.java
@@ -26,7 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Slf4j
 public abstract class AbstractServerHolderImpl<T> implements Holder {
 
-    private final Map<String, T> serviceMap = new ConcurrentHashMap<>();
+    protected final Map<String, T> serviceMap = new ConcurrentHashMap<>();
+    
     @Autowired
     protected SkyWalkerCacheServices skyWalkerCacheServices;
 

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/holder/NacosServerHolder.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/holder/NacosServerHolder.java
@@ -118,7 +118,7 @@ public class NacosServerHolder extends AbstractServerHolderImpl<NamingService> {
                 return NamingFactory.createNamingService(properties);
             }catch (NacosException e) {
                 log.error("start source server fail,taskId:{},sourceClusterId:{}"
-                        , taskId,sourceClusterId, e);
+                        , taskId, sourceClusterId, e);
                 return null;
             }
         });

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/holder/NacosServerHolder.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/holder/NacosServerHolder.java
@@ -13,17 +13,23 @@
 package com.alibaba.nacossync.extension.holder;
 
 import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingFactory;
 import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacossync.constant.SkyWalkerConstants;
 import com.alibaba.nacossync.dao.ClusterAccessService;
+import com.alibaba.nacossync.dao.TaskAccessService;
 import com.alibaba.nacossync.pojo.model.ClusterDO;
+import com.alibaba.nacossync.pojo.model.TaskDO;
 import com.google.common.base.Joiner;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -35,17 +41,30 @@ import org.springframework.stereotype.Service;
 public class NacosServerHolder extends AbstractServerHolderImpl<NamingService> {
 
     private final ClusterAccessService clusterAccessService;
+    
+    private final TaskAccessService taskAccessService;
+    
+    private static ConcurrentHashMap<String,NamingService> globalNameService = new ConcurrentHashMap<>(16);
 
-    public NacosServerHolder(ClusterAccessService clusterAccessService) {
+    public NacosServerHolder(ClusterAccessService clusterAccessService, TaskAccessService taskAccessService) {
         this.clusterAccessService = clusterAccessService;
+        this.taskAccessService = taskAccessService;
     }
 
     @Override
     NamingService createServer(String clusterId, Supplier<String> serverAddressSupplier)
         throws Exception {
+        String newClusterId;
+        if (clusterId.contains(":")) {
+            String[] split = clusterId.split(":");
+            newClusterId = split[1];
+        } else {
+            newClusterId = clusterId;
+        }
+        //代表此时为组合key，确定target集群中的nameService是不同的
         List<String> allClusterConnectKey = skyWalkerCacheServices
-            .getAllClusterConnectKey(clusterId);
-        ClusterDO clusterDO = clusterAccessService.findByClusterId(clusterId);
+            .getAllClusterConnectKey(newClusterId);
+        ClusterDO clusterDO = clusterAccessService.findByClusterId(newClusterId);
         String serverList = Joiner.on(",").join(allClusterConnectKey);
         Properties properties = new Properties();
         properties.setProperty(PropertyKeyConst.SERVER_ADDR, serverList);
@@ -58,6 +77,51 @@ public class NacosServerHolder extends AbstractServerHolderImpl<NamingService> {
         Optional.ofNullable(clusterDO.getPassword()).ifPresent(value ->
             properties.setProperty(PropertyKeyConst.PASSWORD, value)
         );
-        return NamingFactory.createNamingService(properties);
+        NamingService namingService = NamingFactory.createNamingService(properties);
+        globalNameService.put(clusterId,namingService);
+        return namingService;
+    }
+    
+    /**
+     * Get NamingService for different clients
+     * @param clusterId clusterId
+     * @return Returns Naming Service objects for different clusters
+     */
+    public NamingService getNameService(String clusterId){
+        return globalNameService.get(clusterId);
+    }
+    
+    public NamingService getSourceNamingService(String taskId, String sourceClusterId) {
+        String key = taskId + sourceClusterId;
+        return serviceMap.computeIfAbsent(key, k->{
+            try {
+                log.info("Starting create source cluster server, key={}", key);
+                //代表此时为组合key，确定target集群中的nameService是不同的
+                List<String> allClusterConnectKey = skyWalkerCacheServices
+                        .getAllClusterConnectKey(sourceClusterId);
+                ClusterDO clusterDO = clusterAccessService.findByClusterId(sourceClusterId);
+                TaskDO task = taskAccessService.findByTaskId(taskId);
+                String serverList = Joiner.on(",").join(allClusterConnectKey);
+                Properties properties = new Properties();
+                properties.setProperty(PropertyKeyConst.SERVER_ADDR, serverList);
+                properties.setProperty(PropertyKeyConst.NAMESPACE, Optional.ofNullable(clusterDO.getNamespace()).orElse(
+                        Strings.EMPTY));
+                Optional.ofNullable(clusterDO.getUserName()).ifPresent(value ->
+                        properties.setProperty(PropertyKeyConst.USERNAME, value)
+                );
+        
+                Optional.ofNullable(clusterDO.getPassword()).ifPresent(value ->
+                        properties.setProperty(PropertyKeyConst.PASSWORD, value)
+                );
+                properties.setProperty(SkyWalkerConstants.SOURCE_CLUSTERID_KEY,task.getSourceClusterId());
+                properties.setProperty(SkyWalkerConstants.DEST_CLUSTERID_KEY,task.getDestClusterId());
+                return NamingFactory.createNamingService(properties);
+            }catch (NacosException e) {
+                log.error("start source server fail,taskId:{},sourceClusterId:{}"
+                        , taskId,sourceClusterId, e);
+                return null;
+            }
+        });
+        
     }
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ConsulSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ConsulSyncToNacosServiceImpl.java
@@ -96,7 +96,7 @@ public class ConsulSyncToNacosServiceImpl implements SyncService {
     }
 
     @Override
-    public boolean sync(TaskDO taskDO) {
+    public boolean sync(TaskDO taskDO, Integer index) {
         try {
             ConsulClient consulClient = consulServerHolder.get(taskDO.getSourceClusterId());
             NamingService destNamingService = nacosServerHolder.get(taskDO.getDestClusterId());
@@ -106,7 +106,7 @@ public class ConsulSyncToNacosServiceImpl implements SyncService {
             Set<String> instanceKeys = new HashSet<>();
             overrideAllInstance(taskDO, destNamingService, healthServiceList, instanceKeys);
             cleanAllOldInstance(taskDO, destNamingService, instanceKeys);
-            specialSyncEventBus.subscribe(taskDO, this::sync);
+            specialSyncEventBus.subscribe(taskDO, t->sync(t, index));
         } catch (Exception e) {
             log.error("Sync task from consul to nacos was failed, taskId:{}", taskDO.getTaskId(), e);
             metricsManager.recordError(MetricsStatisticsType.SYNC_ERROR);

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/EurekaSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/EurekaSyncToNacosServiceImpl.java
@@ -87,7 +87,7 @@ public class EurekaSyncToNacosServiceImpl implements SyncService {
     }
 
     @Override
-    public boolean sync(TaskDO taskDO) {
+    public boolean sync(TaskDO taskDO,Integer index) {
         try {
 
             EurekaNamingService eurekaNamingService = eurekaServerHolder.get(taskDO.getSourceClusterId());
@@ -107,7 +107,7 @@ public class EurekaSyncToNacosServiceImpl implements SyncService {
                 }
                 addValidInstance(taskDO, destNamingService, eurekaInstances);
             }
-            specialSyncEventBus.subscribe(taskDO, this::sync);
+            specialSyncEventBus.subscribe(taskDO, t->sync(t, index));
         } catch (Exception e) {
             log.error("sync task from eureka to nacos was failed, taskId:{}", taskDO.getTaskId(), e);
             metricsManager.recordError(MetricsStatisticsType.SYNC_ERROR);

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToConsulServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToConsulServiceImpl.java
@@ -99,7 +99,7 @@ public class NacosSyncToConsulServiceImpl implements SyncService {
     }
 
     @Override
-    public boolean sync(TaskDO taskDO) {
+    public boolean sync(TaskDO taskDO, Integer index) {
         try {
             NamingService sourceNamingService =
                 nacosServerHolder.get(taskDO.getSourceClusterId());

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToEurekaServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToEurekaServiceImpl.java
@@ -91,7 +91,7 @@ public class NacosSyncToEurekaServiceImpl implements SyncService {
     }
 
     @Override
-    public boolean sync(TaskDO taskDO) {
+    public boolean sync(TaskDO taskDO, Integer index) {
         try {
             NamingService sourceNamingService =
                 nacosServerHolder.get(taskDO.getSourceClusterId());

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImpl.java
@@ -12,6 +12,7 @@
  */
 package com.alibaba.nacossync.extension.impl;
 
+import static com.alibaba.nacossync.constant.SkyWalkerConstants.SOURCE_CLUSTERID_KEY;
 import static com.alibaba.nacossync.util.NacosUtils.getGroupNameOrDefault;
 
 import com.alibaba.nacos.api.exception.NacosException;
@@ -24,25 +25,26 @@ import com.alibaba.nacossync.cache.SkyWalkerCacheServices;
 import com.alibaba.nacossync.constant.ClusterTypeEnum;
 import com.alibaba.nacossync.constant.MetricsStatisticsType;
 import com.alibaba.nacossync.constant.SkyWalkerConstants;
+import com.alibaba.nacossync.dao.ClusterAccessService;
 import com.alibaba.nacossync.extension.SyncService;
 import com.alibaba.nacossync.extension.annotation.NacosSyncService;
 import com.alibaba.nacossync.extension.holder.NacosServerHolder;
 import com.alibaba.nacossync.monitor.MetricsManager;
 import com.alibaba.nacossync.pojo.model.TaskDO;
-import com.alibaba.nacossync.util.Collections;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
+
+import com.alibaba.nacossync.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -70,43 +72,48 @@ public class NacosSyncToNacosServiceImpl implements SyncService {
     @Autowired
     private NacosServerHolder nacosServerHolder;
 
-    private ConcurrentHashMap<String, TaskDO> allSyncTaskMap = new ConcurrentHashMap<String, TaskDO>();
-
+    private ConcurrentHashMap<String, TaskDO> allSyncTaskMap = new ConcurrentHashMap<>();
+    
+    @Autowired
+    private ClusterAccessService clusterAccessService;
+    
+    public static Map<String, Set<NamingService>> serviceClient=new ConcurrentHashMap<>();
+    
     /**
      * 因为网络故障等原因，nacos sync的同步任务会失败，导致目标集群注册中心缺少同步实例， 为避免目标集群注册中心长时间缺少同步实例，每隔5分钟启动一个兜底工作线程执行一遍全部的同步任务。
      */
     @PostConstruct
     public void startBasicSyncTaskThread() {
-        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r);
-            t.setDaemon(true);
-            t.setName("com.alibaba.nacossync.basic.synctask");
-            return t;
-        });
-
-        executorService.scheduleWithFixedDelay(() -> {
-            if (allSyncTaskMap.size() == 0) {
-                return;
-            }
-
-            try {
-                for (TaskDO taskDO : allSyncTaskMap.values()) {
-                    String taskId = taskDO.getTaskId();
-                    NamingService sourceNamingService =
-                        nacosServerHolder.get(taskDO.getSourceClusterId());
-                    NamingService destNamingService =
-                        nacosServerHolder.get(taskDO.getDestClusterId());
-                    try {
-                        doSync(taskId, taskDO, sourceNamingService, destNamingService);
-                    } catch (Exception e) {
-                        log.error("basic synctask process fail, taskId:{}", taskId, e);
-                        metricsManager.recordError(MetricsStatisticsType.SYNC_ERROR);
-                    }
-                }
-            } catch (Throwable e) {
-                log.warn("basic synctask thread error", e);
-            }
-        }, 0, 300, TimeUnit.SECONDS);
+        // ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(r -> {
+        //     Thread t = new Thread(r);
+        //     t.setDaemon(true);
+        //     t.setName("com.alibaba.nacossync.basic.synctask");
+        //     return t;
+        // });
+        //
+        // executorService.scheduleWithFixedDelay(() -> {
+        //     if (allSyncTaskMap.size() == 0) {
+        //         return;
+        //     }
+        //
+        //     try {
+        //         for (TaskDO taskDO : allSyncTaskMap.values()) {
+        //             String taskId = taskDO.getTaskId();
+        //             NamingService sourceNamingService =
+        //                 nacosServerHolder.get(taskDO.getSourceClusterId());
+        //             NamingService destNamingService =
+        //                 nacosServerHolder.get(taskDO.getDestClusterId());
+        //             try {
+        //                 doSync(taskId, taskDO, sourceNamingService, destNamingService);
+        //             } catch (Exception e) {
+        //                 log.error("basic synctask process fail, taskId:{}", taskId, e);
+        //                 metricsManager.recordError(MetricsStatisticsType.SYNC_ERROR);
+        //             }
+        //         }
+        //     } catch (Throwable e) {
+        //         log.warn("basic synctask thread error", e);
+        //     }
+        // }, 0, 300, TimeUnit.SECONDS);
     }
 
     @Override
@@ -143,33 +150,47 @@ public class NacosSyncToNacosServiceImpl implements SyncService {
     }
 
     @Override
-    public boolean sync(TaskDO taskDO) {
-        String taskId = taskDO.getTaskId();
+    public boolean sync(TaskDO taskDO, Integer index) {
+        log.info("线程 {} 开始同步 {} ", Thread.currentThread().getId(), System.currentTimeMillis());
+        String operationId = taskDO.getOperationId();
+        
         try {
-            NamingService sourceNamingService =
-                nacosServerHolder.get(taskDO.getSourceClusterId());
-            NamingService destNamingService = nacosServerHolder.get(taskDO.getDestClusterId());
-            allSyncTaskMap.put(taskId, taskDO);
+            
+            NamingService sourceNamingService = nacosServerHolder.getSourceNamingService(taskDO.getTaskId(),
+                    taskDO.getSourceClusterId());
+            NamingService destNamingService = getDestNamingService(taskDO, index);
+            allSyncTaskMap.put(operationId, taskDO);
             //防止暂停同步任务后,重新同步/或删除任务以后新建任务不会再接收到新的事件导致不能同步,所以每次订阅事件之前,先全量同步一次任务
-            doSync(taskId, taskDO, sourceNamingService, destNamingService);
-            this.listenerMap.putIfAbsent(taskId, event -> {
+            long startTime = System.currentTimeMillis();
+            doSync(operationId, taskDO, sourceNamingService, destNamingService);
+            log.info("同步一个服务注册耗时:{} ms", System.currentTimeMillis() - startTime);
+            this.listenerMap.putIfAbsent(operationId, event -> {
                 if (event instanceof NamingEvent) {
+                    NamingEvent namingEvent = (NamingEvent) event;
+                    log.info("监听到服务{}信息改变, taskId：{}，实例数:{}，发起同步", namingEvent.getServiceName(),
+                            operationId, namingEvent.getInstances() == null ? null : namingEvent.getInstances().size());
                     try {
-                        doSync(taskId, taskDO, sourceNamingService, destNamingService);
+                        doSync(operationId, taskDO, sourceNamingService, destNamingService);
+                        log.info("监听到服务{}同步结束", namingEvent.getServiceName());
                     } catch (Exception e) {
-                        log.error("event process fail, taskId:{}", taskId, e);
+                        log.error("event process fail, operationId:{}", operationId, e);
                         metricsManager.recordError(MetricsStatisticsType.SYNC_ERROR);
                     }
                 }
             });
             sourceNamingService.subscribe(taskDO.getServiceName(), getGroupNameOrDefault(taskDO.getGroupName()),
-                listenerMap.get(taskId));
+                    listenerMap.get(operationId));
         } catch (Exception e) {
-            log.error("sync task from nacos to nacos was failed, taskId:{}", taskId, e);
+            log.error("sync task from nacos to nacos was failed, operationId:{}", operationId, e);
             metricsManager.recordError(MetricsStatisticsType.SYNC_ERROR);
             return false;
         }
         return true;
+    }
+    
+    private NamingService getDestNamingService(TaskDO taskDO, Integer index) {
+        String key = taskDO.getSourceClusterId() + ":" + taskDO.getDestClusterId() + ":" + index;
+        return nacosServerHolder.get(key);
     }
 
     private void doSync(String taskId, TaskDO taskDO, NamingService sourceNamingService,
@@ -178,75 +199,180 @@ public class NacosSyncToNacosServiceImpl implements SyncService {
             log.info("任务Id:{}上一个同步任务尚未结束", taskId);
             return;
         }
+        //记录目标集群的Client
+        recordNamingService(taskDO, destNamingService);
         try {
-            // 直接从本地保存的serviceInfoMap中取订阅的服务实例
+            
             List<Instance> sourceInstances = sourceNamingService.getAllInstances(taskDO.getServiceName(),
                 getGroupNameOrDefault(taskDO.getGroupName()), new ArrayList<>(), true);
-            // 先删除不存在的
-            this.removeInvalidInstance(taskDO, destNamingService, sourceInstances);
-            // 如果同步实例已经为空代表该服务所有实例已经下线,清除本地持有快照
-            if (sourceInstances.isEmpty()) {
-                sourceInstanceSnapshot.remove(taskId);
-                return;
+            
+            int level = clusterAccessService.findClusterLevel(taskDO.getSourceClusterId());
+            if (CollectionUtils.isNotEmpty(sourceInstances) && sourceInstances.get(0).isEphemeral()) {
+                // TODO 处临实例的批量数据同步,需要获取当前所有的服务实例子，包括不健康的
+                handlerEphemeralInstance(taskDO,destNamingService,sourceInstances, level);
+            }else {
+                //处临持久化实例的批量数据同步
+                handlerPersistenceInstance(taskDO, destNamingService, sourceInstances, level);
             }
-            // 同步实例
-            this.syncNewInstance(taskDO, destNamingService, sourceInstances);
         } finally {
             syncTaskTap.remove(taskId);
         }
     }
-
-    private void syncNewInstance(TaskDO taskDO, NamingService destNamingService,
-        List<Instance> sourceInstances) throws NacosException {
-        Set<String> latestSyncInstance = new TreeSet<>();
-        //再次添加新实例
-        String taskId = taskDO.getTaskId();
-        Set<String> instanceKeys = sourceInstanceSnapshot.get(taskId);
+    
+    private void handlerPersistenceInstance(TaskDO taskDO, NamingService destNamingService,
+            List<Instance> sourceInstances, int level) throws NacosException{
+        List<Instance> needBatchRegisterInstance = new ArrayList<>();
         for (Instance instance : sourceInstances) {
-            if (needSync(instance.getMetadata())) {
-                String instanceKey = composeInstanceKey(instance);
-                if (CollectionUtils.isEmpty(instanceKeys) || !instanceKeys.contains(instanceKey)) {
-                    destNamingService.registerInstance(taskDO.getServiceName(),
-                        getGroupNameOrDefault(taskDO.getGroupName()),
-                        buildSyncInstance(instance, taskDO));
-                }
-                latestSyncInstance.add(instanceKey);
-
+            if (needSync(instance.getMetadata(), level, taskDO.getDestClusterId())) {
+                needBatchRegisterInstance.add(instance);
             }
         }
-        if (CollectionUtils.isNotEmpty(latestSyncInstance)) {
-
-            log.info("任务Id:{},已同步实例个数:{}", taskId, latestSyncInstance.size());
-            sourceInstanceSnapshot.put(taskId, latestSyncInstance);
-        }
-    }
-
-
-    private void removeInvalidInstance(TaskDO taskDO, NamingService destNamingService,
-        List<Instance> sourceInstances) throws NacosException {
-        String taskId = taskDO.getTaskId();
-        if (this.sourceInstanceSnapshot.containsKey(taskId)) {
-            Set<String> oldInstanceKeys = this.sourceInstanceSnapshot.get(taskId);
-            List<String> newInstanceKeys = sourceInstances.stream().map(this::composeInstanceKey)
+        List<Instance> allInstances = destNamingService.getAllInstances(taskDO.getServiceName(),
+                getGroupNameOrDefault(taskDO.getGroupName()), new ArrayList<>(), true);
+        
+        // 获取当前已经同步过来的源集群的所有服务实例
+        List<Instance> destHasSyncInstances = allInstances.stream()
+                .filter(instance -> hasSync(instance, taskDO.getSourceClusterId()))
                 .collect(Collectors.toList());
-            Collection<String> instanceKeys = Collections.subtract(oldInstanceKeys, newInstanceKeys);
-            for (String instanceKey : instanceKeys) {
-                log.info("任务Id:{},移除无效同步实例:{}", taskId, instanceKey);
-                String[] split = instanceKey.split(":", -1);
-                destNamingService
-                    .deregisterInstance(taskDO.getServiceName(),
-                        getGroupNameOrDefault(taskDO.getGroupName()), split[0],
-                        Integer.parseInt(split[1]));
-
+        
+        //获取新增的实例，遍历新增
+        List<Instance> newInstances = new ArrayList<>(needBatchRegisterInstance);
+        instanceRemove(destHasSyncInstances, newInstances);
+        //注册
+        for (Instance newInstance : newInstances) {
+            destNamingService.registerInstance(taskDO.getServiceName(),
+                    getGroupNameOrDefault(taskDO.getGroupName()),buildSyncInstance(newInstance, taskDO));
+        }
+        
+        //获取需要删除的实例，遍历删除
+       
+        List<Instance> removeInstances = new ArrayList<>(destHasSyncInstances);
+        instanceRemove(needBatchRegisterInstance, removeInstances);
+        //执行反注册
+        if (CollectionUtils.isNotEmpty(removeInstances)) {
+            log.info("taskid：{}，服务 {} 发生反注册，执行数量 {} ",taskDO.getTaskId(),taskDO.getServiceName(),removeInstances.size());
+            for (Instance removeInstance : removeInstances) {
+                destNamingService.deregisterInstance(taskDO.getServiceName(),
+                        getGroupNameOrDefault(taskDO.getGroupName()),removeInstance);
             }
-
         }
     }
-
-    private String composeInstanceKey(Instance instance) {
-        return instance.getIp() + ":" + instance.getPort();
+    
+    private void instanceRemove(List<Instance> destHasSyncInstances, List<Instance> newInstances) {
+        List<Instance> needRemoveInstance = new ArrayList<>();
+        for (Instance destHasSyncInstance : destHasSyncInstances) {
+            for (Instance newInstance : newInstances) {
+                if (destHasSyncInstance.equals(newInstance)) {
+                    //如果目标集群已经存在了源集群同步过来的实例，就不需要同步了
+                    needRemoveInstance.add(newInstance);
+                }
+            }
+        }
+        // eg:A Cluster 已经同步到 B Cluster的实例数据，就不需要再重复同步过来了
+        newInstances.removeAll(needRemoveInstance);
     }
-
+    
+    private boolean hasSync(Instance instance, String sourceClusterId) {
+        if (instance.getMetadata()!=null) {
+            String sourceClusterKey = instance.getMetadata().get(SkyWalkerConstants.SYNC_SOURCE_KEY);
+            return sourceClusterKey != null && sourceClusterKey.equals(sourceClusterId);
+        }
+        return false;
+    }
+    
+    /**
+     * process ephemeral instance cluster data sync.
+     * @param taskDO
+     * @param destNamingService
+     * @param sourceInstances
+     * @param level
+     */
+    private void handlerEphemeralInstance(TaskDO taskDO, NamingService destNamingService,
+            List<Instance> sourceInstances, int level) throws NacosException{
+        List<Instance> needBatchRegisterInstance = new ArrayList<>();
+        for (Instance instance : sourceInstances) {
+            if (needSync(instance.getMetadata(),level, taskDO.getDestClusterId())){
+                needBatchRegisterInstance.add(buildSyncInstance(instance, taskDO));
+            }
+        }
+        //当源集群需要同步的实例个数为0时，但是目标集群里面，还存在源集群同步的实例，执行反注册
+        if (needBatchRegisterInstance.size() == 0) {
+            log.debug("service {} need sync Ephemeral instance num is null: serviceName ", taskDO.getServiceName());
+            processDeRegisterInstances(taskDO, destNamingService);
+        }else {
+            // 执行批量注册
+            log.info("batch register，taskId:{}, serviceName：{}，instance num：{}", taskDO.getTaskId(), taskDO.getServiceName(),
+                    needBatchRegisterInstance.size());
+            destNamingService.batchRegisterInstance(taskDO.getServiceName(),
+                    getGroupNameOrDefault(taskDO.getGroupName()), needBatchRegisterInstance);
+        }
+        
+    }
+    
+    /**
+     * 当源集群需要同步的实例个数为0时,目标集群如果还有源集群同步的实例，执行反注册
+     * @param taskDO
+     * @param destNamingService
+     * @throws NacosException
+     */
+    private void processDeRegisterInstances(TaskDO taskDO, NamingService destNamingService) throws NacosException{
+        //如果此时sourceInstance中的实例为空，证明此时实例下线或实例不存在
+        List<Instance> destInstances = destNamingService.getAllInstances(taskDO.getServiceName(),
+                getGroupNameOrDefault(taskDO.getGroupName()), new ArrayList<>(), false);
+        // 如果目标集群中的数据实例也为空了，则测试无需操作
+        if (CollectionUtils.isEmpty(destInstances)) {
+            return;
+        }
+        deRegisterFilter(destInstances,taskDO.getSourceClusterId());
+        if (CollectionUtils.isNotEmpty(destInstances)) {
+            //执行反注册,拿出一个实例即可, 需要处理redo，否则会被重新注册上来
+            destNamingService.deregisterInstance(taskDO.getServiceName(),
+                    getGroupNameOrDefault(taskDO.getGroupName()), destInstances.get(0));
+        }
+    }
+    
+    private void deRegisterFilter(List<Instance> destInstances, String sourceClusterId) {
+        List<Instance> newDestInstance = new ArrayList<>();
+        for (Instance destInstance : destInstances) {
+            Map<String, String> metadata = destInstance.getMetadata();
+            String destSourceClusterId = metadata.get(SkyWalkerConstants.SOURCE_CLUSTERID_KEY);
+            if (needDeregister(destSourceClusterId, sourceClusterId)) {
+                // 需要执行反注册
+                newDestInstance.add(destInstance);
+            }
+        }
+        destInstances = newDestInstance;
+    }
+    
+    private boolean needDeregister(String destClusterId, String sourceClusterId) {
+        if (!StringUtils.isEmpty(destClusterId)) {
+            return destClusterId.equals(sourceClusterId);
+        }
+        return false;
+    }
+    
+    private boolean needSync(Map<String, String> sourceMetaData,int level, String destClusterId){
+        //普通集群（默认）
+        if (level == 0) {
+            return SyncService.super.needSync(sourceMetaData);
+        }
+        //中心集群，只要不是目标集群传过来的实例，都需要同步（扩展功能）
+        if (!destClusterId.equals(sourceMetaData.get(SOURCE_CLUSTERID_KEY))) {
+            return true;
+        }
+        return false;
+    }
+    
+    private void recordNamingService(TaskDO taskDO, NamingService destNamingService) {
+        String key = taskDO.getId() + ":" + taskDO.getServiceName();
+        Set<NamingService> namingServices = serviceClient.get(key);
+        if(namingServices==null){
+            namingServices=new HashSet<>();
+        }
+        // save dest NamingService
+        namingServices.add(destNamingService);
+        serviceClient.put(key,namingServices);
+    }
 
     private Instance buildSyncInstance(Instance instance, TaskDO taskDO) {
         Instance temp = new Instance();
@@ -264,6 +390,8 @@ public class NacosSyncToNacosServiceImpl implements SyncService {
         metaData.put(SkyWalkerConstants.SYNC_SOURCE_KEY,
             skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode());
         metaData.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, taskDO.getSourceClusterId());
+        //标识是同步实例
+        metaData.put(SkyWalkerConstants.SYNC_INSTANCE_TAG, taskDO.getSourceClusterId()+"@@"+taskDO.getVersion());
         temp.setMetadata(metaData);
         return temp;
     }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToZookeeperServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToZookeeperServiceImpl.java
@@ -125,7 +125,7 @@ public class NacosSyncToZookeeperServiceImpl implements SyncService {
     }
 
     @Override
-    public boolean sync(TaskDO taskDO) {
+    public boolean sync(TaskDO taskDO, Integer index) {
         try {
             NamingService sourceNamingService =
                 nacosServerHolder.get(taskDO.getSourceClusterId());

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
@@ -93,7 +93,7 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
     }
 
     @Override
-    public boolean sync(TaskDO taskDO) {
+    public boolean sync(TaskDO taskDO,Integer index) {
         try {
             if (treeCacheMap.containsKey(taskDO.getTaskId())) {
                 return true;

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/ClusterDO.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/ClusterDO.java
@@ -67,5 +67,7 @@ public class ClusterDO implements Serializable {
     private String password;
 
     private String namespace;
-
+    
+    private int clusterLevel;
+    
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/ClusterDO.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/ClusterDO.java
@@ -68,6 +68,6 @@ public class ClusterDO implements Serializable {
 
     private String namespace;
     
-    private int clusterLevel;
+    private Integer clusterLevel;
     
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/TaskDO.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/TaskDO.java
@@ -70,4 +70,9 @@ public class TaskDO implements Serializable {
      * operation id,The operation id follow when the task status changes
      */
     private String operationId;
+    
+    /**
+     * current task status
+     */
+    private Integer status;
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/template/processor/TaskAddProcessor.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/template/processor/TaskAddProcessor.java
@@ -89,7 +89,7 @@ public class TaskAddProcessor implements Processor<TaskAddRequest, TaskAddResult
             taskDO.setTaskStatus(TaskStatusEnum.SYNC.getCode());
             taskDO.setWorkerIp(SkyWalkerUtil.getLocalIp());
             taskDO.setOperationId(SkyWalkerUtil.generateOperationId());
-
+            
         } else {
 
             taskDO.setTaskStatus(TaskStatusEnum.SYNC.getCode());

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/template/processor/TaskUpdateProcessor.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/template/processor/TaskUpdateProcessor.java
@@ -30,6 +30,9 @@ import com.alibaba.nacossync.pojo.model.TaskDO;
 import com.alibaba.nacossync.pojo.request.TaskUpdateRequest;
 import com.alibaba.nacossync.template.Processor;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * @author NacosSync
  * @version $Id: TaskUpdateProcessor.java, v 0.1 2018-10-17 PM11:11 NacosSync Exp $$
@@ -39,6 +42,8 @@ import com.alibaba.nacossync.template.Processor;
 public class TaskUpdateProcessor implements Processor<TaskUpdateRequest, BaseResult> {
     @Autowired
     private TaskAccessService taskAccessService;
+    
+    private Map<String,String> TaskIdAndOperationIdMap = new ConcurrentHashMap<>();
 
     @Override
     public void process(TaskUpdateRequest taskUpdateRequest, BaseResult baseResult,
@@ -56,10 +61,17 @@ public class TaskUpdateProcessor implements Processor<TaskUpdateRequest, BaseRes
             throw new SkyWalkerException("taskDo is null ,taskId is :"
                     + taskUpdateRequest.getTaskId());
         }
-
+        
         taskDO.setTaskStatus(taskUpdateRequest.getTaskStatus());
+        //在id生成之前保存好操作id，可以在删除操作里面进行
+        TaskIdAndOperationIdMap.put(taskDO.getTaskId(),taskDO.getOperationId());
+        
         taskDO.setOperationId(SkyWalkerUtil.generateOperationId());
 
         taskAccessService.addTask(taskDO);
+    }
+    
+    public String getTaskIdAndOperationIdMap(String taskId) {
+        return TaskIdAndOperationIdMap.get(taskId);
     }
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/timer/CheckRunningStatusAllThread.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/timer/CheckRunningStatusAllThread.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacossync.timer;
+
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.pojo.ListView;
+import com.alibaba.nacos.client.naming.utils.CollectionUtils;
+import com.alibaba.nacossync.cache.SkyWalkerCacheServices;
+import com.alibaba.nacossync.constant.MetricsStatisticsType;
+import com.alibaba.nacossync.constant.TaskStatusEnum;
+import com.alibaba.nacossync.dao.TaskAccessService;
+import com.alibaba.nacossync.extension.holder.NacosServerHolder;
+import com.alibaba.nacossync.monitor.MetricsManager;
+import com.alibaba.nacossync.pojo.model.TaskDO;
+import com.google.common.eventbus.EventBus;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ *  when the database task service name is empty, check all the services in the cluster and create a synchronization task.
+ * @ClassName: CheckRunningStatusAllThread
+ * @Author: ChenHao26
+ * @Date: 2022/7/20 10:30
+ * @Description: muti sync data
+ */
+@Slf4j
+public class CheckRunningStatusAllThread implements Runnable{
+    
+    private MetricsManager metricsManager;
+    
+    private SkyWalkerCacheServices skyWalkerCacheServices;
+    
+    private TaskAccessService taskAccessService;
+    
+    private EventBus eventBus;
+    
+    private NacosServerHolder nacosServerHolder;
+    
+    private FastSyncHelper fastSyncHelper;
+    
+    public CheckRunningStatusAllThread(MetricsManager metricsManager, SkyWalkerCacheServices skyWalkerCacheServices,
+            TaskAccessService taskAccessService, EventBus eventBus, NacosServerHolder nacosServerHolder,
+            FastSyncHelper fastSyncHelper) {
+        this.metricsManager = metricsManager;
+        this.skyWalkerCacheServices = skyWalkerCacheServices;
+        this.taskAccessService = taskAccessService;
+        this.eventBus = eventBus;
+        this.nacosServerHolder = nacosServerHolder;
+        this.fastSyncHelper = fastSyncHelper;
+    }
+    
+    /**
+     * 根据ns级别进行数据同步
+     */
+    @Override
+    public void run() {
+        Long startTime = System.currentTimeMillis();
+        try {
+            List<TaskDO> taskDOS = taskAccessService.findServiceNameIsNull()
+                    .stream().filter(t -> t.getStatus() == null || t.getStatus() == 0)
+                    .collect(Collectors.toList());
+    
+            for (TaskDO taskDO : taskDOS) {
+                List<String> serviceNameList = getServiceNameList(taskDO);
+                if (CollectionUtils.isEmpty(serviceNameList)) {
+                   continue;
+                }
+                
+                //如果是null，证明此时没有处理完成
+                List<String> filterService = serviceNameList.stream()
+                        .filter(s -> skyWalkerCacheServices.getFinishedTask(taskDO.getTaskId() + s ) == null)
+                        .collect(Collectors.toList());
+                
+                if (CollectionUtils.isEmpty(filterService)) {
+                    continue;
+                }
+                
+                // 当删除任务后，此时任务的状态为DELETE,不会执行数据同步
+                if (TaskStatusEnum.SYNC.getCode().equals(taskDO.getTaskStatus())) {
+                    fastSyncHelper.syncWithThread(taskDO, filterService);
+                }
+            }
+        }catch (Exception e) {
+            log.warn("CheckRunningStatusThread Exception ", e);
+        }
+        metricsManager.record(MetricsStatisticsType.DISPATCHER_TASK, System.currentTimeMillis() - startTime);
+    }
+    
+    /**
+     * get serviceName list.
+     * @param taskDO task info
+     * @return service list or empty list
+     */
+    private List<String> getServiceNameList(TaskDO taskDO) {
+        NamingService namingService = nacosServerHolder.get(taskDO.getSourceClusterId());
+        try {
+            ListView<String> servicesOfServer = namingService.getServicesOfServer(0, Integer.MAX_VALUE,
+                    taskDO.getGroupName());
+            return servicesOfServer.getData();
+        } catch (Exception e) {
+            log.error("query service list failure",e);
+        }
+        
+        return Collections.emptyList();
+    }
+}

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/timer/QuerySyncTaskTimer.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/timer/QuerySyncTaskTimer.java
@@ -22,6 +22,8 @@ import com.alibaba.nacossync.constant.TaskStatusEnum;
 import com.alibaba.nacossync.dao.TaskAccessService;
 import com.alibaba.nacossync.event.DeleteTaskEvent;
 import com.alibaba.nacossync.event.SyncTaskEvent;
+import com.alibaba.nacossync.extension.SyncManagerService;
+import com.alibaba.nacossync.extension.holder.NacosServerHolder;
 import com.alibaba.nacossync.monitor.MetricsManager;
 import com.alibaba.nacossync.pojo.model.TaskDO;
 import com.google.common.eventbus.EventBus;
@@ -54,13 +56,25 @@ public class QuerySyncTaskTimer implements CommandLineRunner {
 
     @Autowired
     private ScheduledExecutorService scheduledExecutorService;
+    
+    @Autowired
+    private NacosServerHolder nacosServerHolder;
+    
+    @Autowired
+    private SyncManagerService syncManagerService;
+    
+    @Autowired
+    private FastSyncHelper fastSyncHelper;
 
     @Override
     public void run(String... args) {
         /** Fetch the task list from the database every 3 seconds */
         scheduledExecutorService.scheduleWithFixedDelay(new CheckRunningStatusThread(), 0, 3000,
                 TimeUnit.MILLISECONDS);
-
+        
+        scheduledExecutorService.scheduleWithFixedDelay(new CheckRunningStatusAllThread(metricsManager,skyWalkerCacheServices,
+                taskAccessService,eventBus, nacosServerHolder, fastSyncHelper), 0, 3000,
+                TimeUnit.MILLISECONDS);
     }
 
     private class CheckRunningStatusThread implements Runnable {

--- a/nacossync-worker/src/main/resources/application.properties
+++ b/nacossync-worker/src/main/resources/application.properties
@@ -8,12 +8,8 @@ spring.jpa.properties.hibernate.show_sql=false
 spring.cloud.discovery.enabled=false
 
 
-#spring.datasource.url=jdbc:mysql://127.0.0.1:3306/nacos_sync?characterEncoding=utf8
-#spring.datasource.username=root
-#spring.datasource.password=root
-
 spring.datasource.url=jdbc:mysql://127.0.0.1:3306/nacos_sync?characterEncoding=utf8
 spring.datasource.username=root
-spring.datasource.password=hadoop1024
+spring.datasource.password=root
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always

--- a/nacossync-worker/src/main/resources/application.properties
+++ b/nacossync-worker/src/main/resources/application.properties
@@ -8,9 +8,12 @@ spring.jpa.properties.hibernate.show_sql=false
 spring.cloud.discovery.enabled=false
 
 
+#spring.datasource.url=jdbc:mysql://127.0.0.1:3306/nacos_sync?characterEncoding=utf8
+#spring.datasource.username=root
+#spring.datasource.password=root
+
 spring.datasource.url=jdbc:mysql://127.0.0.1:3306/nacos_sync?characterEncoding=utf8
 spring.datasource.username=root
-spring.datasource.password=root
-
+spring.datasource.password=hadoop1024
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/ConsulSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/ConsulSyncToNacosServiceImplTest.java
@@ -67,7 +67,7 @@ public class ConsulSyncToNacosServiceImplTest {
         TaskDO taskDO = mock(TaskDO.class);
         mockSync(taskDO);
         // TODO Test the core logic in the future
-        Assert.assertTrue(consulSyncToNacosService.sync(taskDO));
+        Assert.assertTrue(consulSyncToNacosService.sync(taskDO,null));
     }
 
     @Test
@@ -80,7 +80,7 @@ public class ConsulSyncToNacosServiceImplTest {
 
     @Test(expected = Exception.class)
     public void testConsulSyncToNacosWithException() throws Exception {
-        Assert.assertFalse(consulSyncToNacosService.sync(null));
+        Assert.assertFalse(consulSyncToNacosService.sync(null,null));
     }
 
     @Test(expected = Exception.class)

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/EurekaSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/EurekaSyncToNacosServiceImplTest.java
@@ -61,7 +61,7 @@ public class EurekaSyncToNacosServiceImplTest {
     public void testEurekaSyncToNacos() throws Exception {
         TaskDO taskDO = mock(TaskDO.class);
         mockSync(taskDO);
-        Assert.assertTrue(eurekaSyncToNacosService.sync(taskDO));
+        Assert.assertTrue(eurekaSyncToNacosService.sync(taskDO,null));
     }
 
 
@@ -74,7 +74,7 @@ public class EurekaSyncToNacosServiceImplTest {
     }
     @Test(expected = Exception.class)
     public void testEurekaSyncToNacosWithException() throws Exception {
-        Assert.assertFalse(eurekaSyncToNacosService.sync(null));
+        Assert.assertFalse(eurekaSyncToNacosService.sync(null, null));
     }
     @Test(expected = Exception.class)
     public void testEurekaDeleteToNacosWithException() throws Exception {

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacossync.constant.SkyWalkerConstants;
@@ -52,6 +53,21 @@ public class NacosSyncToNacosServiceImplTest {
         mockSync(taskDO);
         // TODO Test the core logic in the future
         Assert.assertTrue(nacosSyncToNacosService.sync(taskDO,null));
+    }
+    
+    @Test
+    public void testZookeeperSyncToNacosWithTimeSync() throws Exception {
+        TaskDO taskDO = mock(TaskDO.class);
+        try {
+            nacosSyncToNacosService.timeSync(taskDO);
+        }catch (Exception e) {
+            Assert.assertEquals(e, NacosException.class);
+        }
+    }
+    
+    @Test(expected = Exception.class)
+    public void testZookeeperSyncToNacosWithTimeSync2() throws Exception {
+        nacosSyncToNacosService.timeSync(null);
     }
 
     @Test

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImplTest.java
@@ -51,7 +51,7 @@ public class NacosSyncToNacosServiceImplTest {
         TaskDO taskDO = mock(TaskDO.class);
         mockSync(taskDO);
         // TODO Test the core logic in the future
-        Assert.assertTrue(nacosSyncToNacosService.sync(taskDO));
+        Assert.assertTrue(nacosSyncToNacosService.sync(taskDO,null));
     }
 
     @Test
@@ -64,7 +64,7 @@ public class NacosSyncToNacosServiceImplTest {
 
     @Test(expected = Exception.class)
     public void testNacosSyncToNacosWithException() throws Exception {
-        Assert.assertFalse(nacosSyncToNacosService.sync(null));
+        Assert.assertFalse(nacosSyncToNacosService.sync(null, null));
     }
     @Test(expected = Exception.class)
     public void testNacosDeleteToNacosWithException() throws Exception {

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/NacosSyncToZookeeperServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/NacosSyncToZookeeperServiceImplTest.java
@@ -60,7 +60,7 @@ public class NacosSyncToZookeeperServiceImplTest {
 
     @Test(expected = Exception.class)
     public void testNacosSyncToZookeeperWithException() throws Exception {
-        Assert.assertFalse(nacosSyncToZookeeperService.sync(null));
+        Assert.assertFalse(nacosSyncToZookeeperService.sync(null,null));
     }
     @Test(expected = Exception.class)
     public void testNacosDeleteToZookeeperWithException() throws Exception {
@@ -75,7 +75,7 @@ public class NacosSyncToZookeeperServiceImplTest {
         doReturn(sourceNamingService).when(nacosServerHolder).get(any());
 
         //TODO Test the core logic in the future
-        return nacosSyncToZookeeperService.sync(taskDO);
+        return nacosSyncToZookeeperService.sync(taskDO, null);
     }
 
     public boolean mockDelete(TaskDO taskDO) throws Exception {

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImplTest.java
@@ -71,7 +71,7 @@ public class ZookeeperSyncToNacosServiceImplTest {
     public void testZookeeperDeleteToNacos() throws Exception {
         TaskDO taskDO = mock(TaskDO.class);
         mockSync(taskDO);
-        zookeeperSyncToNacosService.sync(taskDO);
+        zookeeperSyncToNacosService.sync(taskDO,null);
 
         Assert.assertTrue(mockDelete(taskDO));
 
@@ -79,7 +79,7 @@ public class ZookeeperSyncToNacosServiceImplTest {
 
     @Test(expected = Exception.class)
     public void tesZookeeperSyncToNacosWithException() throws Exception {
-        Assert.assertFalse(zookeeperSyncToNacosService.sync(null));
+        Assert.assertFalse(zookeeperSyncToNacosService.sync(null, null));
     }
 
     @Test(expected = Exception.class)
@@ -100,7 +100,7 @@ public class ZookeeperSyncToNacosServiceImplTest {
         when(treeCache.getCurrentData(any())).thenReturn(childData);
         doReturn(ClusterTypeEnum.ZK).when(skyWalkerCacheServices).getClusterType(any());
         when(treeCache.getListenable()).thenReturn(listeners);
-        return zookeeperSyncToNacosService.sync(taskDO);
+        return zookeeperSyncToNacosService.sync(taskDO,null);
     }
 
     public boolean mockDelete(TaskDO taskDO) throws Exception {

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/timer/FastSyncHelperTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/timer/FastSyncHelperTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacossync.timer;
+
+import com.alibaba.nacossync.cache.SkyWalkerCacheServices;
+import com.alibaba.nacossync.extension.SyncManagerService;
+import com.alibaba.nacossync.extension.impl.NacosSyncToNacosServiceImpl;
+import com.alibaba.nacossync.monitor.MetricsManager;
+import com.alibaba.nacossync.pojo.model.TaskDO;
+import com.alibaba.nacossync.timer.FastSyncHelper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * test data synchronization.
+ * @ClassName: FastSyncHelperTest
+ * @Author: ChenHao26
+ * @Date: 2022/7/26 15:16
+ * @Description:
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FastSyncHelperTest {
+    
+    @Mock
+    private SkyWalkerCacheServices skyWalkerCacheServices;
+    
+    @Mock
+    private MetricsManager metricsManager;
+    
+    @Mock
+    private SyncManagerService syncManagerService;
+    
+    @Mock
+    private NacosSyncToNacosServiceImpl nacosSyncToNacosService;
+    
+    @InjectMocks
+    @Spy
+    private FastSyncHelper fastSyncHelper;
+    
+    @Test
+    public void testSyncWithThread() {
+        TaskDO taskDO = mock(TaskDO.class);
+        List<TaskDO> list = new ArrayList<>();
+        list.add(taskDO);
+        try {
+            fastSyncHelper.syncWithThread(list);
+        }catch (Exception e) {
+            Assert.assertEquals(e,InterruptedException.class);
+            e.printStackTrace();
+        }
+    }
+    
+    @Test
+    public void testAverageAssign(){
+        int limit = 2;
+        List<String> sourceList = new ArrayList<>();
+        sourceList.add("1");
+        sourceList.add("2");
+        sourceList.add("3");
+        List<List<String>> lists = FastSyncHelper.averageAssign(sourceList, limit);
+        Assert.assertEquals(lists.get(0).size(),limit);
+        Assert.assertNotEquals(lists.get(0).size(),3);
+    }
+}


### PR DESCRIPTION
1. 针对Nacos Client版本升级到2.1.0 dev版本，增加批量注册的请求
2. 实现基于多线程版本的注册数据同步
3. 完成同步中心集群的适配
具体实现方案如下：
https://www.yuque.com/nacos/mydt7c/mo36ke