### PR TITLE
1.3.2nacos<--->2.2.3nacos双向同步时，暂停其中的一个task，重启jvm会抛出空指针 异常 #337

### DIFF
--- a/nacossync-distribution/bin/startup.sh
+++ b/nacossync-distribution/bin/startup.sh
@@ -2,6 +2,14 @@
 
 ACTION=$1
 JAVA_OPT=$2
+shift # 移除第一个参数，即 ACTION
+
+# 处理传递的JVM参数
+JAVA_OPT=""
+while [[ "$1" == -* ]]; do
+    JAVA_OPT="${JAVA_OPT} $1"
+    shift
+done
 
 cygwin=false
 darwin=false

--- a/nacossync-distribution/bin/startup.sh
+++ b/nacossync-distribution/bin/startup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ACTION=$1
+JAVA_OPT=$2
 
 cygwin=false
 darwin=false

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/event/listener/EventListener.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/event/listener/EventListener.java
@@ -16,21 +16,19 @@
  */
 package com.alibaba.nacossync.event.listener;
 
-import javax.annotation.PostConstruct;
-
-import com.alibaba.nacossync.constant.MetricsStatisticsType;
-import com.alibaba.nacossync.monitor.MetricsManager;
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import com.alibaba.nacossync.cache.SkyWalkerCacheServices;
+import com.alibaba.nacossync.constant.MetricsStatisticsType;
 import com.alibaba.nacossync.event.DeleteTaskEvent;
 import com.alibaba.nacossync.event.SyncTaskEvent;
 import com.alibaba.nacossync.extension.SyncManagerService;
+import com.alibaba.nacossync.monitor.MetricsManager;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
 
 /**
  * @author NacosSync
@@ -62,6 +60,7 @@ public class EventListener {
 
         try {
             long start = System.currentTimeMillis();
+            // 如果该任务同步完成,则在finishedTaskMap中添加key:operationId,value:finishedTask
             if (syncManagerService.sync(syncTaskEvent.getTaskDO(), null)) {
                 skyWalkerCacheServices.addFinishedTask(syncTaskEvent.getTaskDO());
                 metricsManager.record(MetricsStatisticsType.SYNC_TASK_RT, System.currentTimeMillis() - start);

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncService.java
@@ -14,8 +14,9 @@ package com.alibaba.nacossync.extension;
 
 import com.alibaba.nacossync.constant.SkyWalkerConstants;
 import com.alibaba.nacossync.pojo.model.TaskDO;
-import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
 
 /**
  * @author NacosSync
@@ -44,6 +45,9 @@ public interface SyncService {
      * Determines that the current instance data is from another source cluster
      */
     default boolean needSync(Map<String, String> sourceMetaData) {
+        if (sourceMetaData == null) {
+            return true;
+        }
         boolean syncTag = StringUtils.isBlank(sourceMetaData.get(SkyWalkerConstants.SYNC_INSTANCE_TAG));
         boolean blank = StringUtils.isBlank(sourceMetaData.get(SkyWalkerConstants.SOURCE_CLUSTERID_KEY));
         return syncTag && blank;

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/holder/NacosServerHolder.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/holder/NacosServerHolder.java
@@ -22,15 +22,15 @@ import com.alibaba.nacossync.dao.TaskAccessService;
 import com.alibaba.nacossync.pojo.model.ClusterDO;
 import com.alibaba.nacossync.pojo.model.TaskDO;
 import com.google.common.base.Joiner;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.logging.log4j.util.Strings;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 /**
  * @author paderlol
@@ -56,6 +56,7 @@ public class NacosServerHolder extends AbstractServerHolderImpl<NamingService> {
         throws Exception {
         String newClusterId;
         if (clusterId.contains(":")) {
+            // clusterId：sourceClusterId:destClusterId:index
             String[] split = clusterId.split(":");
             newClusterId = split[1];
         } else {

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImpl.java
@@ -457,7 +457,7 @@ public class NacosSyncToNacosServiceImpl implements SyncService, InitializingBea
         temp.setHealthy(instance.isHealthy());
         temp.setWeight(instance.getWeight());
         temp.setEphemeral(instance.isEphemeral());
-        Map<String, String> metaData = new HashMap<>(instance.getMetadata());
+        Map<String, String> metaData = new HashMap<>(Optional.ofNullable(instance.getMetadata()).orElse(new HashMap<>()));
         metaData.put(SkyWalkerConstants.DEST_CLUSTERID_KEY, taskDO.getDestClusterId());
         metaData.put(SkyWalkerConstants.SYNC_SOURCE_KEY,
                 skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode());

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/timer/QuerySyncTaskTimer.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/timer/QuerySyncTaskTimer.java
@@ -89,6 +89,7 @@ public class QuerySyncTaskTimer implements CommandLineRunner {
 
                 taskDOS.forEach(taskDO -> {
 
+                    // 通过task operationId来判断该任务是否完成,有值即未完成
                     if ((null != skyWalkerCacheServices.getFinishedTask(taskDO))) {
 
                         return;


### PR DESCRIPTION
环境：有A（nacos1.3.2）和B（nacos2.2.3）两个集群，为A集群创建namespace名为aNamesparce，为B集群创建namespace为bNamespace，在nacos-sync中创建两个task，分别是A->B和B->A双向同步，serviceName均设置为ALL用以同步所有。

问题1：如果将B->A的同步任务暂停（暂停A->B的也可以），然后重启jvm，QuerySyncTaskTimer类会扫描到DELETE的task，发送DeleteTaskEvent，在listener中监听并调用NacosSyncToNacosServiceImpl#delete方法，方法中会调用popNamingService方法获取namingService（从serviceClient   Map中获取），因为这个serviceClient  Map的存储在该版本中只有在sync的listener中才会put，这个DELTE task就永远获取不到namingService，会直接抛出NPE。
<img width="1500" alt="image" src="https://github.com/nacos-group/nacos-sync/assets/53704799/f4bee9a1-16e9-4168-b3c7-9873d26995f5">
<img width="1535" alt="image" src="https://github.com/nacos-group/nacos-sync/assets/53704799/7a903271-fdd3-4496-ab7d-3070cc82aa31">



问题2：如果暂停成功，则老的实例不会被注销掉。如下图所示：
这个serviceClient去重有4个namingService，任务10有两个分别是各个服务引用的NacosNamingService@2b056461和ALL引用的NacosNamingService@7c95663，任务11也有两个，分别是各个服务引用的NacosNamingService@75beac01和ALL引用的NacosNamingService@4dea1449，如果任务名为ALL的话，会获取到单独的ALL namingService，服务注册不是通过ALL注册的，所以注销会失败，服务不会下线，修复完成之后一切正常。
![image](https://github.com/nacos-group/nacos-sync/assets/53704799/5d7623e0-a9dc-4750-9a16-12e853aea007)
![image](https://github.com/nacos-group/nacos-sync/assets/53704799/2e0edd63-4f68-4279-9690-cd75775ade4b)

问题3：如果注册的服务没有元数据，ServiceInfo接口返回的json中，Instance的metadata属性被指定为null，导致NPE;
<img width="1539" alt="image" src="https://github.com/nacos-group/nacos-sync/assets/53704799/122b4cfb-82b1-43b9-af49-5891cfbedb96">
