### PR TITLE
优化以及修复小错误

### DIFF
--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/api/SystemConfigApi.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/api/SystemConfigApi.java
@@ -44,14 +44,18 @@ import com.alibaba.nacossync.template.processor.ConfigQueryProcessor;
 @RestController
 public class SystemConfigApi {
     
-    @Autowired
-    private ConfigQueryProcessor configQueryProcessor;
+    private final ConfigQueryProcessor configQueryProcessor;
     
-    @Autowired
-    private ConfigDeleteProcessor configDeleteProcessor;
+    private final ConfigDeleteProcessor configDeleteProcessor;
     
-    @Autowired
-    private ConfigAddProcessor configAddProcessor;
+    private final ConfigAddProcessor configAddProcessor;
+    
+    public SystemConfigApi(ConfigQueryProcessor configQueryProcessor, ConfigDeleteProcessor configDeleteProcessor,
+            ConfigAddProcessor configAddProcessor) {
+        this.configQueryProcessor = configQueryProcessor;
+        this.configDeleteProcessor = configDeleteProcessor;
+        this.configAddProcessor = configAddProcessor;
+    }
     
     @RequestMapping(path = "/v1/systemconfig/list", method = RequestMethod.GET)
     public ConfigQueryResult tasks(ConfigQueryRequest configQueryRequest) {

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/cache/SkyWalkerCacheServices.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/cache/SkyWalkerCacheServices.java
@@ -97,18 +97,12 @@ public class SkyWalkerCacheServices {
         return finishedTaskMap.get(operationId);
     }
     
-    public FinishedTask getFinishedTask(String operationId) {
-        if (!StringUtils.hasLength(operationId)) {
-            return null;
-        }
-        return finishedTaskMap.get(operationId);
-    }
     
-    public FinishedTask removeFinishedTask(String operationId) {
+    public void removeFinishedTask(String operationId) {
         if (!StringUtils.hasLength(operationId)) {
-            return null;
+            return;
         }
-        return finishedTaskMap.remove(operationId);
+        finishedTaskMap.remove(operationId);
     }
 
     public Map<String, FinishedTask> getFinishedTaskMap() {

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/cache/SkyWalkerCacheServices.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/cache/SkyWalkerCacheServices.java
@@ -90,7 +90,7 @@ public class SkyWalkerCacheServices {
 
         String operationId = SkyWalkerUtil.getOperationId(taskDO);
 
-        if (StringUtils.hasLength(operationId)) {
+        if (!StringUtils.hasLength(operationId)) {
             return null;
         }
 
@@ -98,14 +98,14 @@ public class SkyWalkerCacheServices {
     }
     
     public FinishedTask getFinishedTask(String operationId) {
-        if (StringUtils.hasLength(operationId)) {
+        if (!StringUtils.hasLength(operationId)) {
             return null;
         }
         return finishedTaskMap.get(operationId);
     }
     
     public FinishedTask removeFinishedTask(String operationId) {
-        if (StringUtils.hasLength(operationId)) {
+        if (!StringUtils.hasLength(operationId)) {
             return null;
         }
         return finishedTaskMap.remove(operationId);

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/ClusterTypeEnum.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/ClusterTypeEnum.java
@@ -12,6 +12,8 @@
  */
 package com.alibaba.nacossync.constant;
 
+import lombok.Getter;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +21,7 @@ import java.util.List;
  * @author NacosSync
  * @version $Id: ClusterTypeEnum.java, v 0.1 2018-09-25 下午4:38 NacosSync Exp $$
  */
+@Getter
 public enum ClusterTypeEnum {
 
     CS("CS", "configserver集群"),
@@ -32,18 +35,16 @@ public enum ClusterTypeEnum {
     ZK("ZK", "zookeeper集群");
 
 
-    private String code;
+    private final String code;
 
-    private String desc;
 
     ClusterTypeEnum(String code, String desc) {
         this.code = code;
-        this.desc = desc;
     }
 
     public static List<String> getClusterTypeCodes() {
 
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
 
         for (ClusterTypeEnum clusterTypeEnum : ClusterTypeEnum.values()) {
             list.add(clusterTypeEnum.getCode());
@@ -51,42 +52,7 @@ public enum ClusterTypeEnum {
         return list;
     }
 
-    /**
-     * Getter method for property <tt>code</tt>.
-     *
-     * @return property value of code
-     */
-    public String getCode() {
-        return code;
-    }
-
-    /**
-     * Setter method for property <tt>code </tt>.
-     *
-     * @param code value to be assigned to property code
-     */
-    public void setCode(String code) {
-        this.code = code;
-    }
-
-    /**
-     * Getter method for property <tt>desc</tt>.
-     *
-     * @return property value of desc
-     */
-    public String getDesc() {
-        return desc;
-    }
-
-    /**
-     * Setter method for property <tt>desc </tt>.
-     *
-     * @param desc value to be assigned to property desc
-     */
-    public void setDesc(String desc) {
-        this.desc = desc;
-    }
-
+ 
     public static boolean contains(String clusterType) {
 
         for (ClusterTypeEnum clusterTypeEnum : ClusterTypeEnum.values()) {

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/MetricsStatisticsType.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/MetricsStatisticsType.java
@@ -3,10 +3,13 @@
  */
 package com.alibaba.nacossync.constant;
 
+import lombok.Getter;
+
 /**
  * @author NacosSync
  * @version $Id: MetricsStatisticsType.java, v 0.1 2019年02月28日 下午2:17 NacosSync Exp $
  */
+@Getter
 public enum MetricsStatisticsType {
 
     CACHE_SIZE("nacosSync.finished.taskMap.cacheSize", "任务执行完成缓存列表数"),
@@ -28,15 +31,10 @@ public enum MetricsStatisticsType {
     /**
      * metricsName
      */
-    private String metricsName;
-    private String desc;
+    private final String metricsName;
 
     MetricsStatisticsType(String code, String desc) {
         this.metricsName = code;
-        this.desc = desc;
     }
-
-    public String getMetricsName() {
-        return metricsName;
-    }
+    
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/ResultCodeEnum.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/ResultCodeEnum.java
@@ -16,46 +16,23 @@
  */
 package com.alibaba.nacossync.constant;
 
+import lombok.Getter;
+
 /**
  * @author NacosSync
  * @version $Id: ResultCodeEnum.java, v 0.1 2018-09-25 PM4:38 NacosSync Exp $$
  */
+@Getter
 public enum ResultCodeEnum {
     
     SUCCESS("SUCCESS", "请求成功", "请求成功"),
     SYSTEM_ERROR("SYSTEM_ERROR", "系统异常", "系统异常");
 
-    private String code;
-    private String errorMessage;
-    private String detail;
-
+    private final String code;
+    
     ResultCodeEnum(String code, String errorMessage, String detail) {
         this.code = code;
-        this.errorMessage = errorMessage;
-        this.detail = detail;
     }
-
-    public String getCode() {
-        return code;
-    }
-
-    public void setCode(String code) {
-        this.code = code;
-    }
-
-    public String getErrorMessage() {
-        return errorMessage;
-    }
-
-    public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
-    public String getDetail() {
-        return detail;
-    }
-
-    public void setDetail(String detail) {
-        this.detail = detail;
-    }
+    
+    
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/SkyWalkerConstants.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/SkyWalkerConstants.java
@@ -24,10 +24,10 @@ public class SkyWalkerConstants {
 
     public static final  String UNDERLINE            = "_";
 
-    public static final  String DEST_CLUSTERID_KEY   = "destClusterId";
+    public static final  String DEST_CLUSTER_ID_KEY = "destClusterId";
     public static final  String GROUP_NAME           = "groupName";
     public static final String SYNC_SOURCE_KEY      = "syncSource";
-    public static final String SOURCE_CLUSTERID_KEY = "sourceClusterId";
+    public static final String SOURCE_CLUSTER_ID_KEY = "sourceClusterId";
     public static final String MANAGEMENT_PORT_KEY="management.port";
     public static final String MANAGEMENT_CONTEXT_PATH_KEY="management.context-path";
     

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/TaskStatusEnum.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/constant/TaskStatusEnum.java
@@ -16,6 +16,8 @@
  */
 package com.alibaba.nacossync.constant;
 
+import lombok.Getter;
+
 /**
  * @author NacosSync
  * @version $Id: TaskStatusEnum.java, v 0.1 2018-09-26 上午2:38 NacosSync Exp $$
@@ -30,51 +32,18 @@ public enum TaskStatusEnum {
      * delete the task
      */
     DELETE("DELETE", "任务需要被删除");
+    
 
-    private String code;
-    private String desc;
+    @Getter
+    private final String code;
+    private final String desc;
 
     TaskStatusEnum(String code, String desc) {
         this.code = code;
         this.desc = desc;
     }
-
-    /**
-     * Getter method for property <tt>code</tt>.
-     *
-     * @return property value of code
-     */
-    public String getCode() {
-        return code;
-    }
-
-    /**
-     * Setter method for property <tt>code </tt>.
-     *
-     * @param code value to be assigned to property code
-     */
-    public void setCode(String code) {
-        this.code = code;
-    }
-
-    /**
-     * Getter method for property <tt>desc</tt>.
-     *
-     * @return property value of desc
-     */
-    public String getDesc() {
-        return desc;
-    }
-
-    /**
-     * Setter method for property <tt>desc </tt>.
-     *
-     * @param desc value to be assigned to property desc
-     */
-    public void setDesc(String desc) {
-        this.desc = desc;
-    }
-
+    
+    
     public static boolean contains(String code) {
 
         for (TaskStatusEnum taskStatusEnum : TaskStatusEnum.values()) {

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/ClusterAccessService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/ClusterAccessService.java
@@ -16,19 +16,16 @@
  */
 package com.alibaba.nacossync.dao;
 
+import com.alibaba.nacossync.dao.repository.ClusterRepository;
 import com.alibaba.nacossync.pojo.QueryCondition;
+import com.alibaba.nacossync.pojo.model.ClusterDO;
 import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import com.alibaba.nacossync.dao.repository.ClusterRepository;
-import com.alibaba.nacossync.pojo.model.ClusterDO;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
@@ -44,9 +41,12 @@ import java.util.List;
 @Slf4j
 public class ClusterAccessService implements PageQueryService<ClusterDO> {
 
-    @Autowired
-    private ClusterRepository clusterRepository;
-
+    private final ClusterRepository clusterRepository;
+    
+    public ClusterAccessService(ClusterRepository clusterRepository) {
+        this.clusterRepository = clusterRepository;
+    }
+    
     public ClusterDO insert(ClusterDO clusterDO) {
 
         return clusterRepository.save(clusterDO);

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/TaskAccessService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/TaskAccessService.java
@@ -17,17 +17,15 @@
 package com.alibaba.nacossync.dao;
 
 import com.alibaba.nacossync.constant.SkyWalkerConstants;
+import com.alibaba.nacossync.dao.repository.TaskRepository;
 import com.alibaba.nacossync.pojo.QueryCondition;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.alibaba.nacossync.pojo.model.TaskDO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import com.alibaba.nacossync.dao.repository.TaskRepository;
-import com.alibaba.nacossync.pojo.model.TaskDO;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
@@ -42,9 +40,12 @@ import java.util.List;
 @Service
 public class TaskAccessService implements PageQueryService<TaskDO> {
 
-    @Autowired
-    private TaskRepository taskRepository;
-
+    private final TaskRepository taskRepository;
+    
+    public TaskAccessService(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+    
     public TaskDO findByTaskId(String taskId) {
 
         return taskRepository.findByTaskId(taskId);

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/repository/TaskRepository.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/dao/repository/TaskRepository.java
@@ -42,8 +42,6 @@ public interface TaskRepository extends CrudRepository<TaskDO, Integer>, JpaRepo
     
     /**
      * query service is all，use ns leven sync data
-     * @param serviceName
-     * @return
      */
     List<TaskDO> findAllByServiceNameEqualsIgnoreCase(String serviceName);
     List<TaskDO> findAllByServiceNameNotIgnoreCase(String serviceName);

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncManagerService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncManagerService.java
@@ -39,7 +39,7 @@ public class SyncManagerService implements InitializingBean, ApplicationContextA
 
     protected final SkyWalkerCacheServices skyWalkerCacheServices;
 
-    private ConcurrentHashMap<String, SyncService> syncServiceMap = new ConcurrentHashMap<String, SyncService>();
+    private final ConcurrentHashMap<String, SyncService> syncServiceMap = new ConcurrentHashMap<String, SyncService>();
 
     private ApplicationContext applicationContext;
 

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/SyncService.java
@@ -14,8 +14,9 @@ package com.alibaba.nacossync.extension;
 
 import com.alibaba.nacossync.constant.SkyWalkerConstants;
 import com.alibaba.nacossync.pojo.model.TaskDO;
-import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
 
 /**
  * @author NacosSync
@@ -30,9 +31,8 @@ public interface SyncService {
      * @return
      */
     boolean delete(TaskDO taskDO);
-
+    
     /**
-     * execute sync
      *
      * @param taskDO
      * @param index
@@ -45,7 +45,7 @@ public interface SyncService {
      */
     default boolean needSync(Map<String, String> sourceMetaData) {
         boolean syncTag = StringUtils.isBlank(sourceMetaData.get(SkyWalkerConstants.SYNC_INSTANCE_TAG));
-        boolean blank = StringUtils.isBlank(sourceMetaData.get(SkyWalkerConstants.SOURCE_CLUSTERID_KEY));
+        boolean blank = StringUtils.isBlank(sourceMetaData.get(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY));
         return syncTag && blank;
     }
 
@@ -54,7 +54,7 @@ public interface SyncService {
      * cluster ID of the task
      */
     default boolean needDelete(Map<String, String> destMetaData, TaskDO taskDO) {
-        return StringUtils.equals(destMetaData.get(SkyWalkerConstants.SOURCE_CLUSTERID_KEY),
+        return StringUtils.equals(destMetaData.get(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY),
                 taskDO.getSourceClusterId());
     }
 

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/client/InstanceQueryModel.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/client/InstanceQueryModel.java
@@ -3,6 +3,7 @@ package com.alibaba.nacossync.extension.client;
 import lombok.Data;
 
 @Data
+@Deprecated
 public class InstanceQueryModel {
 
     private String sourceClusterId;

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/client/SyncQueryClient.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/client/SyncQueryClient.java
@@ -3,6 +3,7 @@ package com.alibaba.nacossync.extension.client;
 import com.alibaba.nacossync.pojo.view.TaskModel;
 import java.util.List;
 
+@Deprecated
 public interface SyncQueryClient {
 
 

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/client/impl/NacosSyncQueryClientImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/client/impl/NacosSyncQueryClientImpl.java
@@ -7,14 +7,16 @@ import com.alibaba.nacossync.extension.client.InstanceQueryModel;
 import com.alibaba.nacossync.extension.client.SyncQueryClient;
 import com.alibaba.nacossync.extension.holder.NacosServerHolder;
 import com.alibaba.nacossync.pojo.view.TaskModel;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Slf4j
+@Deprecated
 public class NacosSyncQueryClientImpl implements SyncQueryClient {
 
     private final NacosServerHolder nacosServerHolder;

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/eureka/EurekaBeatReactor.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/eureka/EurekaBeatReactor.java
@@ -29,11 +29,11 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 public class EurekaBeatReactor {
-    private ScheduledExecutorService executorService;
+    private final ScheduledExecutorService executorService;
 
-    private volatile long clientBeatInterval = 5 * 1000;
+    private static final long CLIENT_BEAT_INTERVAL = 5 * 1000;
     private final Map<String, InstanceInfo> eurekaBeat = new ConcurrentHashMap<>();
-    private EurekaHttpClient eurekaHttpClient;
+    private final EurekaHttpClient eurekaHttpClient;
 
     public EurekaBeatReactor(EurekaHttpClient eurekaHttpClient) {
         this.eurekaHttpClient = eurekaHttpClient;
@@ -71,7 +71,7 @@ public class EurekaBeatReactor {
             } catch (Exception e) {
                 log.error("[CLIENT-BEAT] Exception while scheduling beat.", e);
             } finally {
-                executorService.schedule(this, clientBeatInterval, TimeUnit.MILLISECONDS);
+                executorService.schedule(this, CLIENT_BEAT_INTERVAL, TimeUnit.MILLISECONDS);
             }
         }
     }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/eureka/EurekaNamingService.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/eureka/EurekaNamingService.java
@@ -26,8 +26,8 @@ import java.util.Objects;
  * @date 2019-06-26
  */
 public class EurekaNamingService {
-    private EurekaHttpClient eurekaHttpClient;
-    private EurekaBeatReactor beatReactor;
+    private final EurekaHttpClient eurekaHttpClient;
+    private final EurekaBeatReactor beatReactor;
 
 
     public EurekaNamingService(EurekaHttpClient eurekaHttpClient) {

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ConsulSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ConsulSyncToNacosServiceImpl.java
@@ -32,13 +32,13 @@ import com.ecwid.consul.v1.ConsulClient;
 import com.ecwid.consul.v1.QueryParams;
 import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.health.model.HealthService;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Consul 同步 Nacos
@@ -50,8 +50,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 @NacosSyncService(sourceCluster = ClusterTypeEnum.CONSUL, destinationCluster = ClusterTypeEnum.NACOS)
 public class ConsulSyncToNacosServiceImpl implements SyncService {
 
-    @Autowired
-    private MetricsManager metricsManager;
+    private final MetricsManager metricsManager;
 
     private final ConsulServerHolder consulServerHolder;
     private final SkyWalkerCacheServices skyWalkerCacheServices;
@@ -60,14 +59,15 @@ public class ConsulSyncToNacosServiceImpl implements SyncService {
 
     private final SpecialSyncEventBus specialSyncEventBus;
 
-    @Autowired
+    
     public ConsulSyncToNacosServiceImpl(ConsulServerHolder consulServerHolder,
         SkyWalkerCacheServices skyWalkerCacheServices, NacosServerHolder nacosServerHolder,
-        SpecialSyncEventBus specialSyncEventBus) {
+        SpecialSyncEventBus specialSyncEventBus, MetricsManager metricsManager) {
         this.consulServerHolder = consulServerHolder;
         this.skyWalkerCacheServices = skyWalkerCacheServices;
         this.nacosServerHolder = nacosServerHolder;
         this.specialSyncEventBus = specialSyncEventBus;
+        this.metricsManager = metricsManager;
     }
 
     @Override
@@ -146,10 +146,10 @@ public class ConsulSyncToNacosServiceImpl implements SyncService {
         temp.setIp(instance.getService().getAddress());
         temp.setPort(instance.getService().getPort());
         Map<String, String> metaData = new HashMap<>(ConsulUtils.transferMetadata(instance.getService().getTags()));
-        metaData.put(SkyWalkerConstants.DEST_CLUSTERID_KEY, taskDO.getDestClusterId());
+        metaData.put(SkyWalkerConstants.DEST_CLUSTER_ID_KEY, taskDO.getDestClusterId());
         metaData.put(SkyWalkerConstants.SYNC_SOURCE_KEY,
             skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode());
-        metaData.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, taskDO.getSourceClusterId());
+        metaData.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, taskDO.getSourceClusterId());
         temp.setMetadata(metaData);
         return temp;
     }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/EurekaSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/EurekaSyncToNacosServiceImpl.java
@@ -29,12 +29,13 @@ import com.alibaba.nacossync.monitor.MetricsManager;
 import com.alibaba.nacossync.pojo.model.TaskDO;
 import com.alibaba.nacossync.util.NacosUtils;
 import com.netflix.appinfo.InstanceInfo;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * eureka
@@ -182,10 +183,10 @@ public class EurekaSyncToNacosServiceImpl implements SyncService {
         temp.setHealthy(true);
 
         Map<String, String> metaData = new HashMap<>(instance.getMetadata());
-        metaData.put(SkyWalkerConstants.DEST_CLUSTERID_KEY, taskDO.getDestClusterId());
+        metaData.put(SkyWalkerConstants.DEST_CLUSTER_ID_KEY, taskDO.getDestClusterId());
         metaData.put(SkyWalkerConstants.SYNC_SOURCE_KEY,
             skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode());
-        metaData.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, taskDO.getSourceClusterId());
+        metaData.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, taskDO.getSourceClusterId());
         temp.setMetadata(metaData);
         return temp;
     }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToConsulServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToConsulServiceImpl.java
@@ -110,10 +110,10 @@ public class NacosSyncToConsulServiceImpl extends AbstractNacosSync {
         List<String> tags = Lists.newArrayList();
         tags.addAll(instance.getMetadata().entrySet().stream()
                 .map(entry -> String.join(DELIMITER, entry.getKey(), entry.getValue())).collect(Collectors.toList()));
-        tags.add(String.join(DELIMITER, SkyWalkerConstants.DEST_CLUSTERID_KEY, taskDO.getDestClusterId()));
+        tags.add(String.join(DELIMITER, SkyWalkerConstants.DEST_CLUSTER_ID_KEY, taskDO.getDestClusterId()));
         tags.add(String.join(DELIMITER, SkyWalkerConstants.SYNC_SOURCE_KEY,
                 skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode()));
-        tags.add(String.join(DELIMITER, SkyWalkerConstants.SOURCE_CLUSTERID_KEY, taskDO.getSourceClusterId()));
+        tags.add(String.join(DELIMITER, SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, taskDO.getSourceClusterId()));
         newService.setTags(tags);
         return newService;
     }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToEurekaServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToEurekaServiceImpl.java
@@ -95,10 +95,10 @@ public class NacosSyncToEurekaServiceImpl extends AbstractNacosSync {
         DataCenterInfo dataCenterInfo = new MyDataCenterInfo(DataCenterInfo.Name.MyOwn);
         final Map<String, String> instanceMetadata = instance.getMetadata();
         HashMap<String, String> metadata = new HashMap<>(16);
-        metadata.put(SkyWalkerConstants.DEST_CLUSTERID_KEY, taskDO.getDestClusterId());
+        metadata.put(SkyWalkerConstants.DEST_CLUSTER_ID_KEY, taskDO.getDestClusterId());
         metadata.put(SkyWalkerConstants.SYNC_SOURCE_KEY,
                 skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode());
-        metadata.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, taskDO.getSourceClusterId());
+        metadata.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, taskDO.getSourceClusterId());
         metadata.putAll(instanceMetadata);
         String homePageUrl = obtainHomePageUrl(instance, instanceMetadata);
         String serviceName = taskDO.getServiceName();

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImpl.java
@@ -47,7 +47,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static com.alibaba.nacossync.constant.SkyWalkerConstants.SOURCE_CLUSTERID_KEY;
+import static com.alibaba.nacossync.constant.SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY;
 import static com.alibaba.nacossync.util.NacosUtils.getGroupNameOrDefault;
 
 /**
@@ -343,7 +343,7 @@ public class NacosSyncToNacosServiceImpl implements SyncService, InitializingBea
     
     private boolean hasSync(Instance instance, String sourceClusterId) {
         if (instance.getMetadata() != null) {
-            String sourceClusterKey = instance.getMetadata().get(SkyWalkerConstants.SOURCE_CLUSTERID_KEY);
+            String sourceClusterKey = instance.getMetadata().get(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY);
             return sourceClusterKey != null && sourceClusterKey.equals(sourceClusterId);
         }
         return false;
@@ -379,7 +379,7 @@ public class NacosSyncToNacosServiceImpl implements SyncService, InitializingBea
     
     private List<Instance> filterInstancesForRemoval(List<Instance> destInstances, String sourceClusterId) {
         return destInstances.stream().filter(instance -> !instance.getMetadata().isEmpty())
-                .filter(instance -> needDeregister(instance.getMetadata().get(SOURCE_CLUSTERID_KEY), sourceClusterId))
+                .filter(instance -> needDeregister(instance.getMetadata().get(SOURCE_CLUSTER_ID_KEY), sourceClusterId))
                 .collect(Collectors.toList());
         
     }
@@ -398,16 +398,16 @@ public class NacosSyncToNacosServiceImpl implements SyncService, InitializingBea
         }
         // Central cluster, as long as the instance is not from the target cluster,
         // it needs to be synchronized (extended functionality)
-        return !destClusterId.equals(sourceMetaData.get(SOURCE_CLUSTERID_KEY));
+        return !destClusterId.equals(sourceMetaData.get(SOURCE_CLUSTER_ID_KEY));
     }
     
     
     private Instance buildSyncInstance(Instance instance, TaskDO taskDO) {
         Instance temp = getInstance(instance);
-        temp.addMetadata(SkyWalkerConstants.DEST_CLUSTERID_KEY, taskDO.getDestClusterId());
+        temp.addMetadata(SkyWalkerConstants.DEST_CLUSTER_ID_KEY, taskDO.getDestClusterId());
         temp.addMetadata(SkyWalkerConstants.SYNC_SOURCE_KEY,
                 skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode());
-        temp.addMetadata(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, taskDO.getSourceClusterId());
+        temp.addMetadata(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, taskDO.getSourceClusterId());
         //The flag is a synchronous instance
         temp.addMetadata(SkyWalkerConstants.SYNC_INSTANCE_TAG,
                 taskDO.getSourceClusterId() + "@@" + taskDO.getVersion());

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToZookeeperServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/NacosSyncToZookeeperServiceImpl.java
@@ -35,7 +35,6 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.zookeeper.CreateMode;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
@@ -60,8 +59,7 @@ import static com.alibaba.nacossync.util.StringUtils.convertDubboProvidersPath;
 @NacosSyncService(sourceCluster = ClusterTypeEnum.NACOS, destinationCluster = ClusterTypeEnum.ZK)
 public class NacosSyncToZookeeperServiceImpl implements SyncService {
 
-    @Autowired
-    private MetricsManager metricsManager;
+    private final MetricsManager metricsManager;
 
     /**
      * @description The Nacos listener map.
@@ -93,12 +91,13 @@ public class NacosSyncToZookeeperServiceImpl implements SyncService {
 
     private final ZookeeperServerHolder zookeeperServerHolder;
 
-    @Autowired
+  
     public NacosSyncToZookeeperServiceImpl(SkyWalkerCacheServices skyWalkerCacheServices,
-        NacosServerHolder nacosServerHolder, ZookeeperServerHolder zookeeperServerHolder) {
+        NacosServerHolder nacosServerHolder, ZookeeperServerHolder zookeeperServerHolder, MetricsManager metricsManager) {
         this.skyWalkerCacheServices = skyWalkerCacheServices;
         this.nacosServerHolder = nacosServerHolder;
         this.zookeeperServerHolder = zookeeperServerHolder;
+        this.metricsManager = metricsManager;
     }
 
     @Override
@@ -236,10 +235,10 @@ public class NacosSyncToZookeeperServiceImpl implements SyncService {
 
     protected String buildSyncInstance(Instance instance, TaskDO taskDO) throws UnsupportedEncodingException {
         Map<String, String> metaData = new HashMap<>(instance.getMetadata());
-        metaData.put(SkyWalkerConstants.DEST_CLUSTERID_KEY, taskDO.getDestClusterId());
+        metaData.put(SkyWalkerConstants.DEST_CLUSTER_ID_KEY, taskDO.getDestClusterId());
         metaData.put(SkyWalkerConstants.SYNC_SOURCE_KEY,
             skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode());
-        metaData.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, taskDO.getSourceClusterId());
+        metaData.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, taskDO.getSourceClusterId());
 
         String servicePath = monitorPath.computeIfAbsent(taskDO.getTaskId(),
             key -> convertDubboProvidersPath(metaData.get(DubboConstants.INTERFACE_KEY)));

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImpl.java
@@ -32,7 +32,6 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.curator.framework.recipes.cache.TreeCacheEvent;
 import org.apache.curator.utils.CloseableUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -71,18 +70,17 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
     
     private static final String DEFAULT_WEIGHT = "1.0";
     
-    @Autowired
-    private MetricsManager metricsManager;
+    private final MetricsManager metricsManager;
     
     /**
      * Listener cache of Zookeeper format taskId -> PathChildrenCache instance
      */
-    private Map<String, TreeCache> treeCacheMap = new ConcurrentHashMap<>();
+    private final Map<String, TreeCache> treeCacheMap = new ConcurrentHashMap<>();
     
     /**
      * service name cache
      */
-    private Map<String, String> nacosServiceNameMap = new ConcurrentHashMap<>();
+    private final Map<String, String> nacosServiceNameMap = new ConcurrentHashMap<>();
     
     private final ZookeeperServerHolder zookeeperServerHolder;
     
@@ -90,12 +88,14 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
     
     private final SkyWalkerCacheServices skyWalkerCacheServices;
     
-    @Autowired
+   
     public ZookeeperSyncToNacosServiceImpl(ZookeeperServerHolder zookeeperServerHolder,
-            NacosServerHolder nacosServerHolder, SkyWalkerCacheServices skyWalkerCacheServices) {
+            NacosServerHolder nacosServerHolder, SkyWalkerCacheServices skyWalkerCacheServices,
+            MetricsManager metricsManager) {
         this.zookeeperServerHolder = zookeeperServerHolder;
         this.nacosServerHolder = nacosServerHolder;
         this.skyWalkerCacheServices = skyWalkerCacheServices;
+        this.metricsManager = metricsManager;
     }
     
     @Override
@@ -292,9 +292,9 @@ public class ZookeeperSyncToNacosServiceImpl implements SyncService {
     private Map<String, String> buildMetadata(Map<String, String> queryParam, Map<String, String> ipAndPortMap, TaskDO taskDO) {
         Map<String, String> metaData = new HashMap<>(queryParam);
         metaData.put(PROTOCOL_KEY, ipAndPortMap.get(PROTOCOL_KEY));
-        metaData.put(SkyWalkerConstants.DEST_CLUSTERID_KEY, taskDO.getDestClusterId());
+        metaData.put(SkyWalkerConstants.DEST_CLUSTER_ID_KEY, taskDO.getDestClusterId());
         metaData.put(SkyWalkerConstants.SYNC_SOURCE_KEY, skyWalkerCacheServices.getClusterType(taskDO.getSourceClusterId()).getCode());
-        metaData.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, taskDO.getSourceClusterId());
+        metaData.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, taskDO.getSourceClusterId());
         return metaData;
     }
     

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/monitor/MetricsManager.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/monitor/MetricsManager.java
@@ -23,15 +23,19 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class MetricsManager implements CommandLineRunner {
 
-    @Autowired
-    private SkyWalkerCacheServices skyWalkerCacheServices;
+    private final SkyWalkerCacheServices skyWalkerCacheServices;
 
-    @Autowired
-    private ClusterAccessService clusterAccessService;
+    private final ClusterAccessService clusterAccessService;
 
-    @Autowired
-    private TaskAccessService taskAccessService;
-
+    private final TaskAccessService taskAccessService;
+    
+    public MetricsManager(SkyWalkerCacheServices skyWalkerCacheServices, ClusterAccessService clusterAccessService,
+            TaskAccessService taskAccessService) {
+        this.skyWalkerCacheServices = skyWalkerCacheServices;
+        this.clusterAccessService = clusterAccessService;
+        this.taskAccessService = taskAccessService;
+    }
+    
     /**
      * Callback used to run the bean.
      *

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/ClusterDO.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/ClusterDO.java
@@ -17,17 +17,28 @@
 package com.alibaba.nacossync.pojo.model;
 
 import com.alibaba.nacossync.constant.ClusterTypeEnum;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.proxy.HibernateProxy;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.io.Serializable;
-
-import javax.persistence.*;
-
-import lombok.Data;
+import java.util.Objects;
 
 /**
  * @author NacosSync
  * @version $Id: EnvDO.java, v 0.1 2018-09-25 PM 4:17 NacosSync Exp $$
  */
-@Data
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 @Table(name = "cluster")
 public class ClusterDO implements Serializable {
@@ -70,4 +81,30 @@ public class ClusterDO implements Serializable {
     
     private Integer clusterLevel;
     
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        Class<?> oEffectiveClass =
+                o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass()
+                        : o.getClass();
+        Class<?> thisEffectiveClass =
+                this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
+                        .getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) {
+            return false;
+        }
+        ClusterDO clusterDO = (ClusterDO) o;
+        return getId() != null && Objects.equals(getId(), clusterDO.getId());
+    }
+    
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
+                .getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/SystemConfigDO.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/SystemConfigDO.java
@@ -16,15 +16,27 @@
  */
 package com.alibaba.nacossync.pojo.model;
 
-import javax.persistence.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.proxy.HibernateProxy;
 
-import lombok.Data;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
 
 /**
  * @author NacosSync
  * @version $Id: SystemConfig.java, v 0.1 2018-09-26 上午1:48 NacosSync Exp $$
  */
-@Data
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 @Table(name = "system_config")
 public class SystemConfigDO {
@@ -34,5 +46,31 @@ public class SystemConfigDO {
     private String  configKey;
     private String  configValue;
     private String  configDesc;
-
+    
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        Class<?> oEffectiveClass =
+                o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass()
+                        : o.getClass();
+        Class<?> thisEffectiveClass =
+                this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
+                        .getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) {
+            return false;
+        }
+        SystemConfigDO that = (SystemConfigDO) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+    
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
+                .getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/TaskDO.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/model/TaskDO.java
@@ -12,16 +12,28 @@
  */
 package com.alibaba.nacossync.pojo.model;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.proxy.HibernateProxy;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * @author NacosSync
  * @version $Id: TaskDo.java, v 0.1 2018-09-24 PM11:53 NacosSync Exp $$
  */
-@Data
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 @Table(name = "task")
 public class TaskDO implements Serializable {
@@ -71,4 +83,30 @@ public class TaskDO implements Serializable {
      */
     private String operationId;
     
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        Class<?> oEffectiveClass =
+                o instanceof HibernateProxy ? ((HibernateProxy) o).getHibernateLazyInitializer().getPersistentClass()
+                        : o.getClass();
+        Class<?> thisEffectiveClass =
+                this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
+                        .getPersistentClass() : this.getClass();
+        if (thisEffectiveClass != oEffectiveClass) {
+            return false;
+        }
+        TaskDO taskDO = (TaskDO) o;
+        return getId() != null && Objects.equals(getId(), taskDO.getId());
+    }
+    
+    @Override
+    public final int hashCode() {
+        return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
+                .getPersistentClass().hashCode() : getClass().hashCode();
+    }
 }

--- a/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/request/ClusterAddRequest.java
+++ b/nacossync-worker/src/main/java/com/alibaba/nacossync/pojo/request/ClusterAddRequest.java
@@ -17,9 +17,9 @@
 package com.alibaba.nacossync.pojo.request;
 
 import com.alibaba.nacossync.constant.ClusterTypeEnum;
-import java.util.List;
-
 import lombok.Data;
+
+import java.util.List;
 
 /**
  * @author NacosSync

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/ConsulSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/ConsulSyncToNacosServiceImplTest.java
@@ -91,7 +91,7 @@ public class ConsulSyncToNacosServiceImplTest {
     public void mockSync(TaskDO taskDO) throws Exception {
         Instance instance = mock(Instance.class);
         Map<String, String> metadata = Maps.newHashMap();
-        metadata.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, TEST_SOURCE_CLUSTER_ID);
+        metadata.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, TEST_SOURCE_CLUSTER_ID);
         HealthService healthServiceUp = buildHealthService(TEST_INSTANCE_ADDRESS, 8080, Maps.newHashMap());
         HealthService healthServiceDown = buildHealthService(TEST_INSTANCE_ADDRESS, 8081, metadata);
         List<HealthService> healthServiceList = Lists.newArrayList(healthServiceUp, healthServiceDown);
@@ -129,7 +129,7 @@ public class ConsulSyncToNacosServiceImplTest {
         when(taskDO.getDestClusterId()).thenReturn(TEST_DEST_CLUSTER_ID);
         doReturn(destNamingService).when(nacosServerHolder).get(anyString());
         Map<String, String> metadata = Maps.newHashMap();
-        metadata.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, TEST_SOURCE_CLUSTER_ID);
+        metadata.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, TEST_SOURCE_CLUSTER_ID);
         List<Instance> allInstances = Lists.newArrayList(instance);
         doReturn(allInstances).when(destNamingService).getAllInstances(anyString());
         doReturn(metadata).when(instance).getMetadata();

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/EurekaSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/EurekaSyncToNacosServiceImplTest.java
@@ -111,7 +111,7 @@ public class EurekaSyncToNacosServiceImplTest {
         List<InstanceInfo> eurekaInstances = Lists.newArrayList();
         doReturn(eurekaInstances).when(eurekaNamingService).getApplications(anyString());
         Map<String, String> metadata = Maps.newHashMap();
-        metadata.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, TEST_SOURCE_CLUSTER_ID);
+        metadata.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, TEST_SOURCE_CLUSTER_ID);
         List<Instance> allInstances = Lists.newArrayList(instance);
         doReturn(allInstances).when(destNamingService).getAllInstances(anyString());
         doReturn(metadata).when(instance).getMetadata();

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/NacosSyncToNacosServiceImplTest.java
@@ -90,7 +90,7 @@ public class NacosSyncToNacosServiceImplTest {
         doReturn(sourceNamingService).when(nacosServerHolder).get(anyString());
         doNothing().when(sourceNamingService).unsubscribe(any(), any());
         Map<String, String> metadata = Maps.newHashMap();
-        metadata.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, TEST_SOURCE_CLUSTER_ID);
+        metadata.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, TEST_SOURCE_CLUSTER_ID);
         List<Instance> allInstances = Lists.newArrayList(instance);
         doReturn(allInstances).when(sourceNamingService).getAllInstances(anyString());
         doReturn(metadata).when(instance).getMetadata();

--- a/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImplTest.java
+++ b/nacossync-worker/src/test/java/com/alibaba/nacossync/extension/impl/ZookeeperSyncToNacosServiceImplTest.java
@@ -107,7 +107,7 @@ public class ZookeeperSyncToNacosServiceImplTest {
         doNothing().when(treeCache).close();
         Instance instance = mock(Instance.class);
         Map<String, String> metadata = Maps.newHashMap();
-        metadata.put(SkyWalkerConstants.SOURCE_CLUSTERID_KEY, TEST_SOURCE_CLUSTER_ID);
+        metadata.put(SkyWalkerConstants.SOURCE_CLUSTER_ID_KEY, TEST_SOURCE_CLUSTER_ID);
         List<Instance> allInstances = Lists.newArrayList(instance);
 
         doReturn(allInstances).when(destNamingService).getAllInstances(anyString());


### PR DESCRIPTION
#367 @paderlol 
整理代码:
1. 移除枚举类冗余方法以及SkyWalkerCacheServices中未使用方法
2. 部分服务类改用构造注入
3. Entity对象重写equals和hashCode

#360 @MajorHe1
修复 Nacos Sync SkyWalkerCacheServices中使用hasLength替代isEmpty语义未正确问题